### PR TITLE
Add Beast Master

### DIFF
--- a/character.py
+++ b/character.py
@@ -80,6 +80,7 @@ class Character:
         crit: bool = False,
         attack_args: AttackArgs = None,
     ):
+        log.output("Hit with " + weapon.name + ", args " + str(attack_args))
         args = HitArgs(
             target,
             weapon,
@@ -89,9 +90,11 @@ class Character:
         )
         for feat in self.feats:
             feat.hit(args)
+        log.output("\t" + str(args._dmg))
         target.add_damage_sources(args._dmg)
 
     def miss(self, target: Target, weapon: Weapon):
+        log.output("Missed with " + weapon.name)
         args = MissArgs(target, weapon)
         for feat in self.feats:
             feat.miss(args)
@@ -141,6 +144,7 @@ class Character:
             feat.end_turn(target)
         if not self.used_bonus:
             log.record(f"Bonus (None)", 1)
+        log.output("")
 
     def short_rest(self):
         for feat in self.feats:

--- a/character.py
+++ b/character.py
@@ -1,5 +1,5 @@
 from util import prof_bonus
-from feats import Attack, Vex
+from feats import Attack, Vex, Feat
 from target import Target
 from weapons import Weapon
 from events import HitArgs, AttackRollArgs, AttackArgs, MissArgs
@@ -13,7 +13,7 @@ class Character:
         level=None,
         stats=None,
         feats=None,
-        base_feats=None,
+        base_feats: List[Feat]=None,
         feat_schedule=[4, 8, 12, 16, 19],
         default_feats=[Attack(), Vex()],
     ):

--- a/character.py
+++ b/character.py
@@ -65,46 +65,6 @@ class Character:
     def remove_minion(self, minion):
         self.minions.remove(minion)
 
-    def before_attack(self):
-        for feat in self.feats:
-            feat.before_attack()
-
-    def roll_attack(self, target: Target, weapon: Weapon, to_hit: int):
-        args = AttackRollArgs(target=target, weapon=weapon, to_hit=to_hit)
-        for feat in self.feats:
-            feat.roll_attack(args)
-        return args
-
-    def hit(
-        self,
-        target: Target,
-        weapon: Weapon,
-        crit: bool = False,
-        attack_args: AttackArgs = None,
-    ):
-        log.output(lambda: "Hit with " + weapon.name + ", args " + str(attack_args))
-        args = HitArgs(
-            target,
-            weapon,
-            crit=crit,
-            main_action=attack_args.main_action,
-            light_attack=attack_args.light_attack,
-        )
-        for feat in self.feats:
-            feat.hit(args)
-        log.output(lambda: str(args._dmg))
-        target.add_damage_sources(args._dmg)
-
-    def miss(self, target: Target, weapon: Weapon):
-        log.output(lambda: "Missed with " + weapon.name)
-        args = MissArgs(target, weapon)
-        for feat in self.feats:
-            feat.miss(args)
-
-    def enemy_turn(self, target: Target):
-        for feat in self.feats:
-            feat.enemy_turn(target)
-
     def use_bonus(self, source: str):
         if not self.used_bonus:
             log.record(f"Bonus ({source})", 1)
@@ -183,6 +143,7 @@ class Character:
         args = HitArgs(attack=attack, crit=crit, roll=roll)
         for feat in self.feats:
             feat.hit(args)
+        log.output(lambda: str(args._dmg))
         attack.target.add_damage_sources(args._dmg)
 
     def miss(self, attack: AttackArgs):

--- a/character.py
+++ b/character.py
@@ -80,7 +80,7 @@ class Character:
         crit: bool = False,
         attack_args: AttackArgs = None,
     ):
-        log.output("Hit with " + weapon.name + ", args " + str(attack_args))
+        log.output(lambda: "Hit with " + weapon.name + ", args " + str(attack_args))
         args = HitArgs(
             target,
             weapon,
@@ -90,11 +90,11 @@ class Character:
         )
         for feat in self.feats:
             feat.hit(args)
-        log.output("\t" + str(args._dmg))
+        log.output(lambda: str(args._dmg))
         target.add_damage_sources(args._dmg)
 
     def miss(self, target: Target, weapon: Weapon):
-        log.output("Missed with " + weapon.name)
+        log.output(lambda: "Missed with " + weapon.name)
         args = MissArgs(target, weapon)
         for feat in self.feats:
             feat.miss(args)
@@ -144,7 +144,7 @@ class Character:
             feat.end_turn(target)
         if not self.used_bonus:
             log.record(f"Bonus (None)", 1)
-        log.output("")
+        log.output(lambda: "")
 
     def short_rest(self):
         for feat in self.feats:

--- a/events.py
+++ b/events.py
@@ -43,13 +43,13 @@ class AttackRollArgs:
 
     def roll(self):
         if self.adv == self.disadv:
-            log.output(lambda: "Roll: " + str(self.roll1))
+            log.output(lambda: f"Roll: {self.roll1}")
             return self.roll1
         elif self.adv:
-            log.output(lambda: "Roll ADV: " + str(self.roll1) + ", " + str(self.roll2))
+            log.output(lambda: f"Roll ADV: {self.roll1}, {self.roll2}")
             return max(self.roll1, self.roll2)
         else:
-            log.output(lambda: "Roll DIS: " + str(self.roll1) + ", " + str(self.roll2))
+            log.output(lambda: f"Roll DIS: {self.roll1}, {self.roll2}")
             return min(self.roll1, self.roll2)
 
     def hits(self):

--- a/events.py
+++ b/events.py
@@ -1,4 +1,6 @@
 import random
+
+from log import log
 from target import Target
 from weapons import Weapon
 from collections import defaultdict
@@ -35,10 +37,13 @@ class AttackRollArgs:
 
     def roll(self):
         if self.adv == self.disadv:
+            log.output("\tRoll: " + str(self.roll1))
             return self.roll1
         elif self.adv:
+            log.output("\tRoll ADV: " + str(self.roll1) + ", " + str(self.roll2))
             return max(self.roll1, self.roll2)
         else:
+            log.output("\tRoll DIS: " + str(self.roll1) + ", " + str(self.roll2))
             return min(self.roll1, self.roll2)
 
     def hits(self):

--- a/events.py
+++ b/events.py
@@ -37,13 +37,13 @@ class AttackRollArgs:
 
     def roll(self):
         if self.adv == self.disadv:
-            log.output("\tRoll: " + str(self.roll1))
+            log.output(lambda: "Roll: " + str(self.roll1))
             return self.roll1
         elif self.adv:
-            log.output("\tRoll ADV: " + str(self.roll1) + ", " + str(self.roll2))
+            log.output(lambda: "Roll ADV: " + str(self.roll1) + ", " + str(self.roll2))
             return max(self.roll1, self.roll2)
         else:
-            log.output("\tRoll DIS: " + str(self.roll1) + ", " + str(self.roll2))
+            log.output(lambda: "Roll DIS: " + str(self.roll1) + ", " + str(self.roll2))
             return min(self.roll1, self.roll2)
 
     def hits(self):
@@ -68,6 +68,7 @@ class HitArgs:
 
     def add_damage(self, source: str, dmg: int):
         self._dmg[source] += dmg
+
 
     def total_damage(self):
         total = 0

--- a/feats.py
+++ b/feats.py
@@ -177,7 +177,9 @@ class Attack(Feat):
         crit = False
         if roll >= args.weapon.min_crit:
             crit = True
-        if roll + to_hit + result.situational_bonus >= args.target.ac:
+        roll_total = roll + to_hit + result.situational_bonus
+        log.output(lambda: args.weapon.name + " total " + str(roll_total) + " vs " + str(args.target.ac))
+        if roll_total >= args.target.ac:
             self.character.hit(attack=args, crit=crit, roll=roll)
         else:
             self.character.miss(attack=args)
@@ -291,7 +293,7 @@ class Vex(Feat):
         self.vexing = False
 
     def roll_attack(self, args: AttackRollArgs):
-        if self.vexing and not args.attack.weapon.is_other_creature:
+        if self.vexing:
             args.adv = True
             self.vexing = False
 

--- a/feats.py
+++ b/feats.py
@@ -101,6 +101,13 @@ class Archery(Feat):
         if args.attack.weapon.ranged:
             args.situational_bonus += 2
 
+class DualWielder(Feat):
+    def __init__(self):
+        self.name = "DualWielder"
+
+    def apply(selfself, character):
+        super().apply(character)
+        character.dex += 1
 
 class CrossbowExpert(Feat):
     def __init__(self, weapon: Weapon) -> None:

--- a/feats.py
+++ b/feats.py
@@ -149,7 +149,7 @@ class Attack(Feat):
         self.character = character
 
     def roll_attack(self, args):
-        if args.target.vexed:
+        if not args.weapon.is_other_creature and args.target.vexed:
             args.adv = True
             args.target.vexed = False
         if args.target.stunned:
@@ -171,7 +171,6 @@ class Attack(Feat):
         result = self.character.roll_attack(args.target, args.weapon, to_hit)
         roll = result.roll()
         crit = False
-        log.output("Attack roll: " + str(roll) + ", bonus " + str(to_hit) + ", situational: " + str(result.situational_bonus))
         if roll >= args.weapon.min_crit:
             crit = True
         if roll + to_hit + result.situational_bonus >= args.target.ac:
@@ -228,8 +227,9 @@ class EquipWeapon(Feat):
         args.add_damage(f"Weapon:{args.weapon.name}", total_dmg)
         if self.weapon.vex:
             args.target.vexed = True
-        if self.weapon.topple:
+        if self.weapon.topple and not args.target.prone:
             if not args.target.save(self.character.dc(args.weapon.mod)):
+                log.output(lambda: "Knocked prone")
                 args.target.prone = True
 
     def miss(self, args):

--- a/feats.py
+++ b/feats.py
@@ -178,7 +178,7 @@ class Attack(Feat):
         if roll >= args.weapon.min_crit:
             crit = True
         roll_total = roll + to_hit + result.situational_bonus
-        log.output(lambda: args.weapon.name + " total " + str(roll_total) + " vs " + str(args.target.ac))
+        log.output(lambda: f"{args.weapon.name} total {roll_total} vs {args.target.ac}")
         if roll_total >= args.target.ac:
             self.character.hit(attack=args, crit=crit, roll=roll)
         else:

--- a/feats.py
+++ b/feats.py
@@ -223,7 +223,9 @@ class EquipWeapon(Feat):
             dmg2 = self.damage(crit=args.crit)
             dmg = max(dmg, dmg2)
         total_dmg = dmg + weapon.bonus
-        if not args.attack.has_tag("light"):
+        if args.attack.weapon.base is not None:
+            total_dmg += args.attack.weapon.base
+        elif not args.attack.has_tag("light"):
             total_dmg += args.attack.character.mod(weapon.mod)
         args.add_damage(f"Weapon:{weapon.name}", total_dmg)
         if weapon.topple:

--- a/feats.py
+++ b/feats.py
@@ -171,6 +171,7 @@ class Attack(Feat):
         result = self.character.roll_attack(args.target, args.weapon, to_hit)
         roll = result.roll()
         crit = False
+        log.output("Attack roll: " + str(roll) + ", bonus " + str(to_hit) + ", situational: " + str(result.situational_bonus))
         if roll >= args.weapon.min_crit:
             crit = True
         if roll + to_hit + result.situational_bonus >= args.target.ac:
@@ -218,8 +219,12 @@ class EquipWeapon(Feat):
             dmg2 = self.damage(crit=args.crit)
             dmg = max(dmg, dmg2)
         total_dmg = dmg + self.weapon.bonus
-        if not args.light_attack:
-            total_dmg += self.character.mod(self.weapon.mod)
+        base = self.weapon.base
+        if base == None:
+            base = self.character.mod(self.weapon.mod)
+        elif isinstance(base, str):
+            base = self.character.mod(base)
+        total_dmg += base
         args.add_damage(f"Weapon:{args.weapon.name}", total_dmg)
         if self.weapon.vex:
             args.target.vexed = True

--- a/log.py
+++ b/log.py
@@ -2,8 +2,9 @@ from collections import defaultdict
 
 
 class Log:
-    def __init__(self):
+    def __init__(self, detailed = False):
         self.record_ = defaultdict(int)
+        self.detailed = detailed
 
     def record(self, type, val):
         self.record_[type] += val
@@ -12,5 +13,8 @@ class Log:
         for key in self.record_:
             print(f"Type: {key} Value: {self.record_[key]}")
 
+    def output(self, message):
+        if (self.detailed):
+            print(message)
 
-log = Log()
+log = Log(detailed=False)

--- a/log.py
+++ b/log.py
@@ -15,6 +15,6 @@ class Log:
 
     def output(self, message):
         if (self.detailed):
-            print(message)
+            print(message())
 
 log = Log(detailed=False)

--- a/ranger.py
+++ b/ranger.py
@@ -12,7 +12,7 @@ from feats import (
     CrossbowExpert,
     Feat,
     Spellcasting,
-    EquipWeapon,
+    EquipWeapon, DualWielder,
 )
 from weapons import HandCrossbow, Weapon, Shortsword, Scimitar, Rapier
 from spells import HuntersMark
@@ -184,17 +184,21 @@ class BeastMasterRanger(Character):
         self.magic_weapon = get_magic_weapon(level)
         base_feats = []
         maul = BeastMaul(base=2 + prof_bonus(level))
-        if level < 4:
-            main_weapon = Shortsword(bonus=self.magic_weapon)
-        else:
-            main_weapon = Rapier(bonus = self.magic_weapon)
+        shortsword = Shortsword(bonus=self.magic_weapon)
+        rapier = Rapier(bonus = self.magic_weapon)
         other_shortsword = Shortsword(bonus=self.magic_weapon, name="Offhand Shortsword", base="dex" if level >= 2 else 0)
         scimitar = Scimitar(bonus=self.magic_weapon, base="dex" if level >= 2 else 0)
         base_feats.append(EquipWeapon(maul))
-        base_feats.append(EquipWeapon(main_weapon))
+        base_feats.append(EquipWeapon(shortsword))
+        base_feats.append(EquipWeapon(rapier))
         base_feats.append(EquipWeapon(scimitar))
         base_feats.append(EquipWeapon(other_shortsword))
         def attacks():
+            if self.has_feat("DualWielder"):
+                main_weapon = rapier
+            else:
+                main_weapon = shortsword
+
             if self.level >= 3:
                 if self.use_bonus("beast"):
                     yield maul
@@ -236,7 +240,7 @@ class BeastMasterRanger(Character):
             level=level,
             stats=[10, 17, 10, 10, 16, 10],
             feats=[
-                ASI([["dex", 1]]),
+                DualWielder(),
                 ASI([["dex", 2]]),
                 ASI([["wis", 2]]),
                 ASI([["wis", 2]]),

--- a/ranger.py
+++ b/ranger.py
@@ -23,10 +23,10 @@ from log import log
 
 
 # ranger casts either summon fey or hunter's mark, returns true if ranger still has action
-def cast_spell(character: Character, summon_fey: int) -> bool:
+def cast_spell(character: Character, summon_fey_threshold: int) -> bool:
     spellcasting = character.feat("Spellcasting")
     slot = spellcasting.highest_slot()
-    if summon_fey and slot >= summon_fey and not spellcasting.is_concentrating():
+    if summon_fey_threshold and slot >= summon_fey_threshold and not spellcasting.is_concentrating():
         spell = SummonFey(
             slot,
             caster_level=character.level,
@@ -42,13 +42,13 @@ def cast_spell(character: Character, summon_fey: int) -> bool:
         return True
 
 class RangerAction(Feat):
-    def __init__(self, attacks, summon_fey: int = None) -> None:
+    def __init__(self, attacks, summon_fey_threshold: int = None) -> None:
         self.name = "RangerAction"
         self.attacks = attacks
-        self.summon_fey = summon_fey
+        self.summon_fey_threshold = summon_fey_threshold
 
     def action(self, target: Target):
-        has_action = cast_spell(self.character, self.summon_fey)
+        has_action = cast_spell(self.character, self.summon_fey_threshold)
         if has_action:
             for weapon in self.attacks:
                 log.record("main attack", 1)
@@ -151,7 +151,7 @@ class GloomstalkerRanger(Character):
         else:
             attacks = [weapon]
         base_feats.append(EquipWeapon(weapon))
-        base_feats.append(RangerAction(attacks=attacks, summon_fey=4))
+        base_feats.append(RangerAction(attacks=attacks, summon_fey_threshold=4))
         base_feats.append(Spellcasting(level, half=True))
         if level >= 20:
             base_feats.append(HuntersMarkFeat(10, True, ))

--- a/ranger.py
+++ b/ranger.py
@@ -221,10 +221,11 @@ class BeastMasterAction(Feat):
                 self.character.attack(target, self.off_hand_nick)
             else:
                 self.character.attack(target, self.main_hand)
+                tags = [] if self.character.level >= 2 else ["light"]
                 if self.character.use_bonus("light weapon"):
-                    self.character.attack(target, self.off_hand_other)
+                    self.character.attack(target, self.off_hand_other, tags=tags)
                 else:
-                    self.character.attack(target, self.off_hand_nick)
+                    self.character.attack(target, self.off_hand_nick, tags=tags)
 
 
 class BeastMasterRanger(Character):
@@ -237,22 +238,14 @@ class BeastMasterRanger(Character):
         rapier = Rapier(bonus = self.magic_weapon)
         other_shortsword = Shortsword(
             bonus=self.magic_weapon,
-            name="Offhand Shortsword",
-            base="dex" if level >= 2 else 0,
+            name="OffhandShortsword",
         )
-        scimitar = Scimitar(bonus=self.magic_weapon, base="dex" if level >= 2 else 0)
+        scimitar = Scimitar(bonus=self.magic_weapon)
         base_feats.append(EquipWeapon(maul))
         base_feats.append(EquipWeapon(shortsword))
         base_feats.append(EquipWeapon(rapier))
         base_feats.append(EquipWeapon(scimitar))
         base_feats.append(EquipWeapon(other_shortsword))
-        base_feats.append(BeastMasterAction(
-            beast=beast,
-            maul=maul,
-            main_hand=shortsword if level < 4 else rapier,
-            off_hand_nick=scimitar,
-            off_hand_other=other_shortsword,
-        ))
         base_feats.append(Spellcasting(level, half=True))
         base_feats.append(BeastChargeFeat(character=self))
 
@@ -265,6 +258,13 @@ class BeastMasterRanger(Character):
             base_feats.append(HuntersMarkFeat(6, True, ))
         else:
             base_feats.append(HuntersMarkFeat(6, False, filter=beast_only_level_11))
+        base_feats.append(BeastMasterAction(
+            beast=beast,
+            maul=maul,
+            main_hand=rapier if level >= 4 else shortsword,
+            off_hand_nick=scimitar,
+            off_hand_other=other_shortsword,
+        ))
         super().init(
             level=level,
             stats=[10, 17, 10, 10, 16, 10],

--- a/ranger.py
+++ b/ranger.py
@@ -2,7 +2,7 @@ from events import AttackArgs, AttackRollArgs, HitArgs
 from target import Target
 from util import (
     magic_weapon,
-    roll_dice,
+    roll_dice, prof_bonus,
 )
 from character import Character
 from feats import (
@@ -13,7 +13,7 @@ from feats import (
     Spellcasting,
     EquipWeapon,
 )
-from weapons import HandCrossbow, Weapon
+from weapons import HandCrossbow, Weapon, Shortsword, Scimitar
 from spells import HuntersMark
 from summons import FeySummon, SummonFey
 from log import log
@@ -36,23 +36,26 @@ class RangerAction(Feat):
             spellcasting.cast(spell)
         else:
             if not spellcasting.is_concentrating() and self.character.use_bonus(
-                "HuntersMark"
+                    "HuntersMark"
             ):
                 spellcasting.cast(HuntersMark(slot))
-            for weapon in self.attacks:
+            for weapon in self.attacks(self.character):
                 log.record("main attack", 1)
                 self.character.attack(target, weapon, main_action=True)
 
 
 class HuntersMarkFeat(Feat):
-    def __init__(self, die: int, adv: bool = False) -> None:
+    def __init__(self, die: int, adv: bool = False, filter=None) -> None:
         self.name = "HuntersMarkFeat"
         self.die = die
         self.adv = adv
+        self.filter = filter
 
     def roll_attack(self, args: AttackRollArgs):
         spellcasting = self.character.feat("Spellcasting")
         if not spellcasting.concentrating_on("HuntersMark"):
+            return
+        if self.filter and not self.filter(args):
             return
         if self.adv:
             args.adv = True
@@ -60,6 +63,8 @@ class HuntersMarkFeat(Feat):
     def hit(self, args: HitArgs):
         spellcasting = self.character.feat("Spellcasting")
         if not spellcasting.concentrating_on("HuntersMark"):
+            return
+        if self.filter and not self.filter(args):
             return
         num = 2 if args.crit else 1
         args.add_damage("HuntersMark", roll_dice(num, self.die))
@@ -98,7 +103,24 @@ class Gloomstalker(Feat):
         self.used_attack = False
 
 
-class Ranger(Character):
+class BeastMaul(Weapon):
+    def __init__(self, base, **kwargs):
+        super().__init__(
+            name="Beast Maul", num_dice=1, die=8, mod="wis", base=base, **kwargs
+        )
+
+
+class BeastChargeFeat(Feat):
+    def __init__(self):
+        self.name = "BeastChargeFeat"
+
+    def hit(self, args: HitArgs):
+        if (isinstance(args.weapon, BeastMaul)):
+            num = 2 if args.crit else 1
+            args.add_damage("Charge", roll_dice(num, 6))
+
+
+class GloomstalkerRanger(Character):
     def __init__(self, level):
         self.magic_weapon = magic_weapon(level)
         base_feats = []
@@ -109,14 +131,14 @@ class Ranger(Character):
         else:
             attacks = [weapon]
         base_feats.append(EquipWeapon(weapon))
-        base_feats.append(RangerAction(attacks=attacks))
+        base_feats.append(RangerAction(attacks=lambda c: attacks))
         base_feats.append(Spellcasting(level, half=True))
         if level >= 20:
-            base_feats.append(HuntersMarkFeat(10, True))
+            base_feats.append(HuntersMarkFeat(10, True, ))
         elif level >= 17:
-            base_feats.append(HuntersMarkFeat(6, True))
+            base_feats.append(HuntersMarkFeat(6, True, ))
         else:
-            base_feats.append(HuntersMarkFeat(6, False))
+            base_feats.append(HuntersMarkFeat(6, False, ))
         if level >= 3:
             base_feats.append(Gloomstalker(weapon))
         super().init(
@@ -124,6 +146,68 @@ class Ranger(Character):
             stats=[10, 17, 10, 10, 16, 10],
             feats=[
                 CrossbowExpert(weapon),
+                ASI([["dex", 2]]),
+                ASI([["wis", 2]]),
+                ASI([["wis", 2]]),
+                ASI(),
+            ],
+            base_feats=base_feats,
+        )
+
+
+class BeastMasterRanger(Character):
+    def __init__(self, level):
+        self.magic_weapon = magic_weapon(level)
+        base_feats = []
+        maul = BeastMaul(base=2 + prof_bonus(level))
+        shortsword = Shortsword(bonus=self.magic_weapon)
+        other_shortsword = Shortsword(bonus=self.magic_weapon, name="Offhand Shortsword", base="dex" if level >= 2 else 0)
+        scimitar = Scimitar(bonus=self.magic_weapon, base="dex" if level >= 2 else 0)
+        base_feats.append(EquipWeapon(maul))
+        base_feats.append(EquipWeapon(shortsword))
+        base_feats.append(EquipWeapon(scimitar))
+        def attacks(character):
+            if self.level >= 3:
+                if self.use_bonus("beast"):
+                    yield maul
+                    if level >= 11:
+                        yield maul
+                    yield shortsword
+                    yield shortsword
+                    yield scimitar
+                else:
+                    if level >= 5:
+                        yield maul
+                        if level >= 11:
+                            yield maul
+                        yield shortsword
+                        yield scimitar
+                    else:
+                        yield shortsword
+                        yield scimitar
+            else:
+                yield shortsword
+                if self.use_bonus("light weapon"):
+                    yield other_shortsword
+                else:
+                    yield scimitar
+        base_feats.append(RangerAction(attacks=attacks))
+        base_feats.append(Spellcasting(level, half=True))
+
+        def filter(args: HitArgs) -> bool:
+            return (not isinstance(args.weapon, BeastMaul)) or (level >= 11)
+
+        if level >= 20:
+            base_feats.append(HuntersMarkFeat(10, True, ))
+        elif level >= 17:
+            base_feats.append(HuntersMarkFeat(6, True, ))
+        else:
+            base_feats.append(HuntersMarkFeat(6, False, filter=filter))
+        super().init(
+            level=level,
+            stats=[10, 17, 10, 10, 16, 10],
+            feats=[
+                ASI([["dex", 1]]),
                 ASI([["dex", 2]]),
                 ASI([["wis", 2]]),
                 ASI([["wis", 2]]),

--- a/ranger.py
+++ b/ranger.py
@@ -41,7 +41,7 @@ class RangerAction(Feat):
                     "HuntersMark"
             ):
                 spellcasting.cast(HuntersMark(slot))
-            for weapon in self.attacks(self.character):
+            for weapon in self.attacks():
                 log.record("main attack", 1)
                 self.character.attack(target, weapon, tags=["main_action"])
 
@@ -153,7 +153,7 @@ class GloomstalkerRanger(Character):
         else:
             attacks = [weapon]
         base_feats.append(EquipWeapon(weapon))
-        base_feats.append(RangerAction(attacks=lambda c: attacks, summon_fey=4))
+        base_feats.append(RangerAction(attacks=lambda: attacks, summon_fey=4))
         base_feats.append(Spellcasting(level, half=True))
         if level >= 20:
             base_feats.append(HuntersMarkFeat(10, True, ))
@@ -194,7 +194,7 @@ class BeastMasterRanger(Character):
         base_feats.append(EquipWeapon(main_weapon))
         base_feats.append(EquipWeapon(scimitar))
         base_feats.append(EquipWeapon(other_shortsword))
-        def attacks(character):
+        def attacks():
             if self.level >= 3:
                 if self.use_bonus("beast"):
                     yield maul

--- a/ranger.py
+++ b/ranger.py
@@ -112,15 +112,15 @@ class BeastMaul(Weapon):
 
 
 class BeastChargeFeat(Feat):
-    def __init__(self, dc: int):
+    def __init__(self, character: Character):
         self.name = "BeastChargeFeat"
-        self.dc = dc
+        self.character = Character
 
     def hit(self, args: HitArgs):
-        if (isinstance(args.weapon, BeastMaul)):
+        if isinstance(args.weapon, BeastMaul):
             num = 2 if args.crit else 1
             args.add_damage("Charge", roll_dice(num, 6))
-            if not args.target.prone and not args.target.save(self.dc):
+            if not args.target.prone and not args.target.save(self.character.dc("wis")):
                 args.target.prone = True
                 log.output(lambda: "Knocked prone by Charge")
 
@@ -199,7 +199,7 @@ class BeastMasterRanger(Character):
                     yield scimitar
         base_feats.append(RangerAction(attacks=attacks))
         base_feats.append(Spellcasting(level, half=True))
-        base_feats.append(BeastChargeFeat(dc = 8 + prof_bonus(level) + 3))
+        base_feats.append(BeastChargeFeat(character = self))
 
         def filter(args: HitArgs) -> bool:
             return (not isinstance(args.weapon, BeastMaul)) or (level >= 11)

--- a/ranger.py
+++ b/ranger.py
@@ -14,7 +14,7 @@ from feats import (
     Spellcasting,
     EquipWeapon,
 )
-from weapons import HandCrossbow, Weapon, Shortsword, Scimitar
+from weapons import HandCrossbow, Weapon, Shortsword, Scimitar, Rapier
 from spells import HuntersMark
 from summons import FeySummon, SummonFey
 from log import log
@@ -184,11 +184,14 @@ class BeastMasterRanger(Character):
         self.magic_weapon = get_magic_weapon(level)
         base_feats = []
         maul = BeastMaul(base=2 + prof_bonus(level))
-        shortsword = Shortsword(bonus=self.magic_weapon)
+        if level < 4:
+            main_weapon = Shortsword(bonus=self.magic_weapon)
+        else:
+            main_weapon = Rapier(bonus = self.magic_weapon)
         other_shortsword = Shortsword(bonus=self.magic_weapon, name="Offhand Shortsword", base="dex" if level >= 2 else 0)
         scimitar = Scimitar(bonus=self.magic_weapon, base="dex" if level >= 2 else 0)
         base_feats.append(EquipWeapon(maul))
-        base_feats.append(EquipWeapon(shortsword))
+        base_feats.append(EquipWeapon(main_weapon))
         base_feats.append(EquipWeapon(scimitar))
         base_feats.append(EquipWeapon(other_shortsword))
         def attacks(character):
@@ -197,21 +200,21 @@ class BeastMasterRanger(Character):
                     yield maul
                     if level >= 11:
                         yield maul
-                    yield shortsword
-                    yield shortsword
+                    yield main_weapon
+                    yield main_weapon
                     yield scimitar
                 else:
                     if level >= 5:
                         yield maul
                         if level >= 11:
                             yield maul
-                        yield shortsword
+                        yield main_weapon
                         yield scimitar
                     else:
-                        yield shortsword
+                        yield main_weapon
                         yield scimitar
             else:
-                yield shortsword
+                yield main_weapon
                 if self.use_bonus("light weapon"):
                     yield other_shortsword
                 else:
@@ -220,7 +223,7 @@ class BeastMasterRanger(Character):
         base_feats.append(Spellcasting(level, half=True))
         base_feats.append(BeastChargeFeat(character=self))
 
-        def filter(args: HitArgs) -> bool:
+        def beast_only_level_11(args: HitArgs) -> bool:
             return (not isinstance(args.attack.weapon, BeastMaul)) or (level >= 11)
 
         if level >= 20:
@@ -228,7 +231,7 @@ class BeastMasterRanger(Character):
         elif level >= 17:
             base_feats.append(HuntersMarkFeat(6, True, ))
         else:
-            base_feats.append(HuntersMarkFeat(6, False, filter=filter))
+            base_feats.append(HuntersMarkFeat(6, False, filter=beast_only_level_11))
         super().init(
             level=level,
             stats=[10, 17, 10, 10, 16, 10],

--- a/sim.py
+++ b/sim.py
@@ -13,7 +13,7 @@ from fighter import (
 from rogue import Rogue
 from wizard import Wizard
 from paladin import Paladin
-from ranger import Ranger
+from ranger import GloomstalkerRanger, BeastMasterRanger
 from cleric import Cleric
 from target import Target
 from log import log
@@ -64,10 +64,11 @@ if __name__ == "__main__":
         [
             ["Monk", Monk],
             ["Champion Figher", ChampionFighter],
-            # ["Battlemaster Fighter", PrecisionTrippingFighter],
+            ["Battlemaster Fighter", PrecisionTrippingFighter],
             ["Barbarian", Barbarian],
             ["Paladin", Paladin],
-            ["Ranger", Ranger],
+            ["Gloomstalker", GloomstalkerRanger],
+            ["Beast Master", BeastMasterRanger],
             ["Rogue", Rogue],
             ["Wizard", Wizard],
             ["Cleric", Cleric],

--- a/target.py
+++ b/target.py
@@ -70,8 +70,9 @@ class Target:
 
     def save(self, dc):
         roll = random.randint(1, 20)
-        log.output(lambda : "Save roll: " + str(roll))
-        return roll + self.save_bonus >= dc
+        total = roll + self.save_bonus
+        log.output(lambda : f"Save roll: {roll} total {total} vs {dc}")
+        return total >= dc
 
     def turn(self):
         if self.prone:

--- a/target.py
+++ b/target.py
@@ -70,7 +70,9 @@ class Target:
             log.record(f"Damage ({key})", self._dmg_log[key])
 
     def save(self, dc):
-        return random.randint(1, 20) + self.save_bonus >= dc
+        roll = random.randint(1, 20)
+        log.output(lambda : "Save roll: " + str(roll))
+        return roll + self.save_bonus >= dc
 
     def stun(self):
         self.stun_turns = 1

--- a/util.py
+++ b/util.py
@@ -63,10 +63,10 @@ def roll_dice(num: int, size: int, max_reroll: int = 0) -> float:
     total = 0
     for _ in range(num):
         roll = random.randint(1, size)
-        log.output(lambda: "\tRoll " + str(roll) + " of " + str(size))
+        log.output(lambda: f"\tRoll {roll} on d{size}")
         if roll <= max_reroll:
             roll = random.randint(1, size)
-            log.output(lambda: "\t\tReroll " + str(roll) + " of " + str(size))
+            log.output(lambda: f"\t\tReroll {roll} on d{size}")
         total += roll
     return total
 

--- a/util.py
+++ b/util.py
@@ -2,6 +2,8 @@ import random
 import math
 from collections import defaultdict
 
+from log import log
+
 SPELL_SLOTS_ARR = [
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],  # 0
     [0, 2, 0, 0, 0, 0, 0, 0, 0, 0],  # 1
@@ -61,8 +63,10 @@ def roll_dice(num, size, max_reroll=0):
     total = 0
     for _ in range(num):
         roll = random.randint(1, size)
+        log.output("\t\tRoll " + str(roll) + " of " + str(size))
         if roll <= max_reroll:
             roll = random.randint(1, size)
+            log.output("\t\tReroll " + str(roll) + " of " + str(size))
         total += roll
     return total
 

--- a/util.py
+++ b/util.py
@@ -63,10 +63,10 @@ def roll_dice(num, size, max_reroll=0):
     total = 0
     for _ in range(num):
         roll = random.randint(1, size)
-        log.output("\t\tRoll " + str(roll) + " of " + str(size))
+        log.output(lambda: "\tRoll " + str(roll) + " of " + str(size))
         if roll <= max_reroll:
             roll = random.randint(1, size)
-            log.output("\t\tReroll " + str(roll) + " of " + str(size))
+            log.output(lambda: "\t\tReroll " + str(roll) + " of " + str(size))
         total += roll
     return total
 

--- a/weapons.py
+++ b/weapons.py
@@ -12,6 +12,7 @@ class Weapon:
         ranged=False,
         topple=False,
         base=None,
+        is_other_creature=False,
     ) -> None:
         self.name = name
         self.num_dice = num_dice
@@ -24,7 +25,7 @@ class Weapon:
         self.ranged = ranged
         self.topple = topple
         self.base = base
-
+        self.is_other_creature = is_other_creature
 
 class Glaive(Weapon):
     def __init__(self, **kwargs):

--- a/weapons.py
+++ b/weapons.py
@@ -11,6 +11,7 @@ class Weapon:
         min_crit=20,
         ranged=False,
         topple=False,
+        base=None,
     ) -> None:
         self.name = name
         self.num_dice = num_dice
@@ -22,6 +23,7 @@ class Weapon:
         self.min_crit = min_crit
         self.ranged = ranged
         self.topple = topple
+        self.base = base
 
 
 class Glaive(Weapon):
@@ -46,9 +48,9 @@ class Greatsword(Weapon):
 
 
 class Shortsword(Weapon):
-    def __init__(self, **kwargs):
+    def __init__(self, name="Shortsword", **kwargs):
         super().__init__(
-            name="Shortsword", num_dice=1, die=6, mod="dex", vex=True, **kwargs
+            name=name, num_dice=1, die=6, mod="dex", vex=True, **kwargs
         )
 
 

--- a/weapons.py
+++ b/weapons.py
@@ -54,6 +54,11 @@ class Shortsword(Weapon):
             name=name, num_dice=1, die=6, mod=mod, vex=True, **kwargs
         )
 
+class Rapier(Weapon):
+    def __init__(self, mod="dex", name="Rapier", **kwargs):
+        super().__init__(
+            name=name, num_dice=1, die=8, mod=mod, vex=True, **kwargs
+        )
 
 class Scimitar(Weapon):
     def __init__(self, mod="dex", **kwargs):

--- a/weapons.py
+++ b/weapons.py
@@ -12,7 +12,6 @@ class Weapon:
         ranged=False,
         topple=False,
         base=None,
-        is_other_creature=False,
     ) -> None:
         self.name = name
         self.num_dice = num_dice
@@ -25,7 +24,6 @@ class Weapon:
         self.ranged = ranged
         self.topple = topple
         self.base = base
-        self.is_other_creature = is_other_creature
 
 class Glaive(Weapon):
     def __init__(self, **kwargs):


### PR DESCRIPTION
- Adds a Beast Master option, always using Hunter's Mark with a shortsword and scimitar
- From level 7 onward, Beast is assumed to use the Disengage option when attacking as part of a bonus action, to better enable Charge
- Adds a concept of a weapon being from another creature, used by Vex (could not use summon mechanic as Beast acts during Ranger's turn)
- Adds a detailed logging option to display events as the occur within a combat, best used for a single run of the simulation at a single level

![ranger](https://github.com/cmdli/dndsim/assets/799593/aeebc1f2-dfb7-479a-9e3b-4d2db5f929ec)
