### PR TITLE
Add custom keyword arguments for creating builds

### DIFF
--- a/rogue.py
+++ b/rogue.py
@@ -111,11 +111,16 @@ class AssassinRogue(Character):
         magic_weapon = get_magic_weapon(level)
         sneak_attack = math.ceil(level / 2)
         base_feats = []
-        shortsword = Shortsword(bonus=magic_weapon)
-        scimitar = Scimitar(bonus=magic_weapon)
-        base_feats.append(EquipWeapon(shortsword))
-        base_feats.append(EquipWeapon(scimitar))
-        base_feats.append(AttackAction(attacks=[shortsword], nick_attacks=[scimitar]))
+        if level >= 5 and kwargs["booming_blade"]:
+            rapier = Rapier(bonus=magic_weapon)
+            base_feats.append(EquipWeapon(rapier))
+            base_feats.append(BoomingBlade(self, rapier))
+        else:
+            shortsword = Shortsword(bonus=magic_weapon)
+            scimitar = Scimitar(bonus=magic_weapon)
+            base_feats.append(EquipWeapon(shortsword))
+            base_feats.append(EquipWeapon(scimitar))
+            base_feats.append(AttackAction(attacks=[shortsword], nick_attacks=[scimitar]))
         base_feats.append(SneakAttack(sneak_attack))
         if level >= 3:
             base_feats.append(SteadyAim())

--- a/rogue.py
+++ b/rogue.py
@@ -107,11 +107,11 @@ class DeathStrike(Feat):
 
 
 class AssassinRogue(Character):
-    def __init__(self, level, **kwargs):
+    def __init__(self, level, booming_blade=False):
         magic_weapon = get_magic_weapon(level)
         sneak_attack = math.ceil(level / 2)
         base_feats = []
-        if level >= 5 and kwargs["booming_blade"]:
+        if level >= 5 and booming_blade:
             rapier = Rapier(bonus=magic_weapon)
             base_feats.append(EquipWeapon(rapier))
             base_feats.append(BoomingBlade(self, rapier))

--- a/sim.py
+++ b/sim.py
@@ -51,14 +51,14 @@ def write_data(file, data):
         writer.writerows(data)
 
 
-class Sim:
+class CharacterConfig:
     def __init__(self, name: str, constructor, **kwargs):
         self.name = name
         self.constructor = constructor
         self.args = kwargs
 
 
-def test_characters(characters: List[Sim], start: int, end: int, extra_args: Dict[str, bool]):
+def test_characters(characters: List[CharacterConfig], start: int, end: int, extra_args: Dict[str, bool]):
     data = [["Level", "Character", "DPR"]]
     for level in range(start, end + 1):
         for character in characters:
@@ -68,22 +68,19 @@ def test_characters(characters: List[Sim], start: int, end: int, extra_args: Dic
     return data
 
 
-def sim(name: str, constructor, **kwargs):
-    return Sim(name, constructor, **kwargs)
-
-
 CHARACTER_MAPPING = {
-    "monk": sim("Monk", Monk),
-    "champion": sim("Champion Fighter", ChampionFighter),
-    "battlemaster": sim("Battlemaster Fighter", ChampionFighter),
-    "barbarian": sim("Barbarian", Barbarian),
-    "paladin": sim("Paladin", Paladin),
-    "gloomstalker": sim("Gloomstalker Ranger", GloomstalkerRanger),
-    "beastmaster": sim("Beastmaster Ranger", BeastMasterRanger),
-    "assassin": sim("Assassin (BB)", AssassinRogue),
-    "wizard": sim("Wizard", Wizard),
-    "cleric": sim("Cleric", Cleric),
-    "au": sim("Assault Unit 2 1", AssaultUnit),
+    "monk": CharacterConfig("Monk", Monk),
+    "champion": CharacterConfig("Champion Fighter", ChampionFighter),
+    "battlemaster": CharacterConfig("Battlemaster Fighter", ChampionFighter),
+    "barbarian": CharacterConfig("Barbarian", Barbarian),
+    "paladin": CharacterConfig("Paladin", Paladin),
+    "gloomstalker": CharacterConfig("Gloomstalker Ranger", GloomstalkerRanger),
+    "beastmaster": CharacterConfig("Beastmaster Ranger", BeastMasterRanger),
+    "rogue": CharacterConfig("Assassin", AssassinRogue),
+    "arcane_trickster": CharacterConfig("Arcane Trickster", ArcaneTricksterRogue),
+    "wizard": CharacterConfig("Wizard", Wizard),
+    "cleric": CharacterConfig("Cleric", Cleric),
+    "au": CharacterConfig("Assault Unit 2 1", AssaultUnit),
 }
 
 ALL_CHARACTERS = [

--- a/sim.py
+++ b/sim.py
@@ -73,19 +73,17 @@ def sim(name: str, constructor, **kwargs):
 
 
 CHARACTER_MAPPING = {
-    # "monk": sim("Monk", Monk),
-    # "champion": sim("Champion Fighter", ChampionFighter),
-    # "battlemaster": sim("Battlemaster Fighter", ChampionFighter),
-    # "barbarian": sim("Barbarian", Barbarian),
-    # "paladin": sim("Paladin", Paladin),
-    # "gloomstalker": sim("Gloomstalker Ranger", GloomstalkerRanger),
-    # "beastmaster": sim("Beastmaster Ranger", BeastMasterRanger),
-    "assassin1": sim("Assassin (BB)", AssassinRogue, booming_blade=True),
-    "assassin2": sim("Assassin", AssassinRogue, booming_blade=False),
-    "arcanetrickster": sim("Arcane Trickster", ArcaneTricksterRogue)
-    # "wizard": sim("Wizard", Wizard),
-    # "cleric": sim("Cleric", Cleric),
-    # "au": sim("Assault Unit 2 1", AssaultUnit),
+    "monk": sim("Monk", Monk),
+    "champion": sim("Champion Fighter", ChampionFighter),
+    "battlemaster": sim("Battlemaster Fighter", ChampionFighter),
+    "barbarian": sim("Barbarian", Barbarian),
+    "paladin": sim("Paladin", Paladin),
+    "gloomstalker": sim("Gloomstalker Ranger", GloomstalkerRanger),
+    "beastmaster": sim("Beastmaster Ranger", BeastMasterRanger),
+    "assassin": sim("Assassin (BB)", AssassinRogue),
+    "wizard": sim("Wizard", Wizard),
+    "cleric": sim("Cleric", Cleric),
+    "au": sim("Assault Unit 2 1", AssaultUnit),
 }
 
 ALL_CHARACTERS = [
@@ -102,8 +100,7 @@ ALL_CHARACTERS = [
 
 def get_characters(names: Set[str]):
     if "all" in names:
-        return CHARACTER_MAPPING.values()
-        # names = set(ALL_CHARACTERS)
+        names = set(ALL_CHARACTERS)
     characters = []
     for name in names:
         characters.append(CHARACTER_MAPPING[name.lower()])

--- a/sim.py
+++ b/sim.py
@@ -9,7 +9,7 @@ from fighter import (
     PrecisionTrippingFighter,
     TWFFighter,
 )
-from rogue import AssassinRogue
+from rogue import AssassinRogue, ArcaneTricksterRogue
 from wizard import Wizard
 from paladin import Paladin
 from ranger import GloomstalkerRanger, BeastMasterRanger
@@ -51,26 +51,41 @@ def write_data(file, data):
         writer.writerows(data)
 
 
-def test_characters(characters, start: int, end: int, extra_args: Dict[str, bool]):
+class Sim:
+    def __init__(self, name: str, constructor, **kwargs):
+        self.name = name
+        self.constructor = constructor
+        self.args = kwargs
+
+
+def test_characters(characters: List[Sim], start: int, end: int, extra_args: Dict[str, bool]):
     data = [["Level", "Character", "DPR"]]
     for level in range(start, end + 1):
-        for [name, Creator] in characters:
-            data.append([level, name, test_dpr(Creator(level, **extra_args), level)])
+        for character in characters:
+            args = dict(extra_args)
+            args.update(character.args)
+            data.append([level, character.name, test_dpr(character.constructor(level, **args), level)])
     return data
 
 
+def sim(name: str, constructor, **kwargs):
+    return Sim(name, constructor, **kwargs)
+
+
 CHARACTER_MAPPING = {
-    "monk": ["Monk", Monk],
-    "champion": ["Champion Fighter", ChampionFighter],
-    "battlemaster": ["Battlemaster Fighter", ChampionFighter],
-    "barbarian": ["Barbarian", Barbarian],
-    "paladin": ["Paladin", Paladin],
-    "gloomstalker": ["Gloomstalker Ranger", GloomstalkerRanger],
-    "beastmaster": ["Beastmaster Ranger", BeastMasterRanger],
-    "rogue": ["Rogue", AssassinRogue],
-    "wizard": ["Wizard", Wizard],
-    "cleric": ["Cleric", Cleric],
-    "au": ["Assault Unit 2 1", AssaultUnit],
+    # "monk": sim("Monk", Monk),
+    # "champion": sim("Champion Fighter", ChampionFighter),
+    # "battlemaster": sim("Battlemaster Fighter", ChampionFighter),
+    # "barbarian": sim("Barbarian", Barbarian),
+    # "paladin": sim("Paladin", Paladin),
+    # "gloomstalker": sim("Gloomstalker Ranger", GloomstalkerRanger),
+    # "beastmaster": sim("Beastmaster Ranger", BeastMasterRanger),
+    "assassin1": sim("Assassin (BB)", AssassinRogue, booming_blade=True),
+    "assassin2": sim("Assassin", AssassinRogue, booming_blade=False),
+    "arcanetrickster": sim("Arcane Trickster", ArcaneTricksterRogue)
+    # "wizard": sim("Wizard", Wizard),
+    # "cleric": sim("Cleric", Cleric),
+    # "au": sim("Assault Unit 2 1", AssaultUnit),
 }
 
 ALL_CHARACTERS = [
@@ -87,7 +102,8 @@ ALL_CHARACTERS = [
 
 def get_characters(names: Set[str]):
     if "all" in names:
-        names = set(ALL_CHARACTERS)
+        return CHARACTER_MAPPING.values()
+        # names = set(ALL_CHARACTERS)
     characters = []
     for name in names:
         characters.append(CHARACTER_MAPPING[name.lower()])


### PR DESCRIPTION
Adds `**kwargs` support that directly reaches the character's constructor.

The below graph was generated with:
```
CHARACTER_MAPPING = {
    "assassin1": sim("Assassin (BB)", AssassinRogue, booming_blade=True),
    "assassin2": sim("Assassin", AssassinRogue, booming_blade=False),
    "arcanetrickster": sim("Arcane Trickster", ArcaneTricksterRogue)
}
```

![rogue_compare](https://github.com/user-attachments/assets/15e11f1c-a21c-4965-a462-34ff554e38d0)
