### PR TITLE
Remove ! and ? from this.character in feats

### DIFF
--- a/dndsim/src/classes/Rogue.ts
+++ b/dndsim/src/classes/Rogue.ts
@@ -29,7 +29,7 @@ class SneakAttack extends Feat {
     attackResult(event: AttackResultEvent): void {
         if (event.hit && !this.used) {
             this.used = true
-            const level = this.character!.getClassLevel("Rogue")
+            const level = this.character.getClassLevel("Rogue")
             const diceCount = Math.ceil(level / 2)
             event.addDamage({
                 source: "SneakAttack",
@@ -49,7 +49,7 @@ class SteadyAim extends Feat {
     }
 
     beforeAction(): void {
-        if (this.character!.bonus.use("SteadyAim")) {
+        if (this.character.bonus.use("SteadyAim")) {
             this.enabled = true
         }
     }
@@ -118,7 +118,7 @@ class Assassinate extends Feat {
             // Simulate the initiative check
             const rogueRoll =
                 Math.max(rollDice(1, 20), rollDice(1, 20)) +
-                this.character!.mod("dex")
+                this.character.mod("dex")
             const enemyRoll = rollDice(1, 20)
             if (rogueRoll > enemyRoll) {
                 this.adv = true
@@ -166,7 +166,7 @@ class DeathStrike extends Feat {
     attackResult(event: AttackResultEvent): void {
         if (event.hit && this.enabled) {
             this.enabled = false
-            if (!event.attack.target.save(this.character!.dc("dex"))) {
+            if (!event.attack.target.save(this.character.dc("dex"))) {
                 event.dmgMultiplier *= 2
             }
         }
@@ -193,7 +193,7 @@ class BoomingBladeAction extends Feat {
     }
 
     action(data: ActionEvent): void {
-        this.character?.weaponAttack({
+        this.character.weaponAttack({
             target: data.target,
             weapon: this.weapon,
             tags: ["main_action", "booming_blade"],
@@ -206,7 +206,7 @@ class BoomingBladeAction extends Feat {
         }
 
         let extraDice = 0
-        const level = this.character!.level
+        const level = this.character.level
         if (level >= 17) {
             extraDice = 3
         } else if (level >= 11) {
@@ -239,14 +239,14 @@ class RogueAction extends Feat {
     }
 
     action(data: ActionEvent): void {
-        this.character!.weaponAttack({
+        this.character.weaponAttack({
             target: data.target,
             weapon: this.weapon,
             tags: ["main_action"],
         })
 
         if (this.nickWeapon) {
-            this.character!.weaponAttack({
+            this.character.weaponAttack({
                 target: data.target,
                 weapon: this.nickWeapon,
                 tags: ["light"],

--- a/dndsim/src/feats/epic/IrresistibleOffense.ts
+++ b/dndsim/src/feats/epic/IrresistibleOffense.ts
@@ -19,7 +19,7 @@ export class IrresistibleOffense extends Feat {
         if (args.hit && args.roll === 20) {
             args.addDamage({
                 source: "IrresistibleOffense",
-                flatDmg: this.character?.stat(this.mod),
+                flatDmg: this.character.stat(this.mod),
             })
         }
     }

--- a/dndsim/src/feats/epic/SpellRecall.ts
+++ b/dndsim/src/feats/epic/SpellRecall.ts
@@ -20,7 +20,7 @@ export class SpellRecall extends Feat {
     castSpell(event: CastSpellEvent): void {
         if (event.spell.slot > 0 && event.spell.slot <= 4) {
             if (rollDice(1, 4) === event.spell.slot) {
-                this.character?.spells.addSlot(event.spell.slot)
+                this.character.spells.addSlot(event.spell.slot)
             }
         }
     }

--- a/dndsim/src/feats/general/Grappler.ts
+++ b/dndsim/src/feats/general/Grappler.ts
@@ -33,7 +33,7 @@ export class Grappler extends Feat {
         const attack = event.attack
         const weapon = attack.attack.weapon()
         if (weapon && weapon.hasTag(UnarmedWeapon)) {
-            this.character!.grapple(attack.target)
+            this.character.grapple(attack.target)
         }
     }
 }

--- a/dndsim/src/feats/general/GreatWeaponMaster.ts
+++ b/dndsim/src/feats/general/GreatWeaponMaster.ts
@@ -23,11 +23,11 @@ export class GreatWeaponMaster extends Feat {
         if (data.attack.attack.weapon()?.hasTag(HeavyWeapon)) {
             data.addDamage({
                 source: "GreatWeaponMaster",
-                flatDmg: this.character?.prof(),
+                flatDmg: this.character.prof(),
             })
         }
-        if (data.crit && this.character?.bonus.use("GreatWeaponMaster")) {
-            this.character?.weaponAttack({
+        if (data.crit && this.character.bonus.use("GreatWeaponMaster")) {
+            this.character.weaponAttack({
                 target: data.attack.target,
                 weapon: this.weapon,
             })

--- a/dndsim/src/feats/general/Poisoner.ts
+++ b/dndsim/src/feats/general/Poisoner.ts
@@ -22,12 +22,12 @@ export class Poisoner extends Feat {
     }
 
     longRest(): void {
-        this.uses = this.character!.prof()
+        this.uses = this.character.prof()
     }
 
     beginTurn(): void {
         // TODO: Add ability to turn this on and off
-        if (this.character!.bonus.use()) {
+        if (this.character.bonus.use()) {
             this.uses--
             this.enabled = true
         }
@@ -39,7 +39,7 @@ export class Poisoner extends Feat {
         }
         if (this.enabled) {
             this.enabled = false
-            if (!event.attack.target.save(this.character!.dc(this.stat))) {
+            if (!event.attack.target.save(this.character.dc(this.stat))) {
                 event.addDamage({
                     source: "Poisoner",
                     dice: [8, 8],

--- a/dndsim/src/feats/general/ShieldMaster.ts
+++ b/dndsim/src/feats/general/ShieldMaster.ts
@@ -26,7 +26,7 @@ export class ShieldMaster extends Feat {
         const attack = event.attack.attack
         const target = event.attack.target
         if (attack.weapon() && !attack.isRanged()) {
-            if (target.save(this.character!.dc("str"))) {
+            if (target.save(this.character.dc("str"))) {
                 this.used = true
                 target.knockProne()
             }

--- a/dndsim/src/sim/coreFeats/Topple.ts
+++ b/dndsim/src/sim/coreFeats/Topple.ts
@@ -14,8 +14,8 @@ export class Topple extends Feat {
             weapon &&
             weapon.mastery === "Topple" &&
             data.hit &&
-            this.character?.masteries.has("Topple") &&
-            !target.save(this.character?.dc(weapon.mod(this.character)))
+            this.character.masteries.has("Topple") &&
+            !target.save(this.character.dc(weapon.mod(this.character)))
         ) {
             target.knockProne()
         }

--- a/dndsim/src/sim/coreFeats/Vex.ts
+++ b/dndsim/src/sim/coreFeats/Vex.ts
@@ -28,7 +28,7 @@ export class Vex extends Feat {
             data.hit &&
             weapon &&
             weapon.mastery === "Vex" &&
-            this.character?.masteries.has("Vex")
+            this.character.masteries.has("Vex")
         ) {
             this.vexing = true
         }


### PR DESCRIPTION
It's a bit confusing now that in each feat, we pass in `character` to `apply`, but then use `this.character` in each callback. I think it would be cleaner if we either always used the passed-in character, or always used `this.character`.