### PR TITLE
Add damage types to damage rolls and fix barbarian damage rolls

### DIFF
--- a/dndsim/src/classes/Barbarian.ts
+++ b/dndsim/src/classes/Barbarian.ts
@@ -51,7 +51,7 @@ class Rage extends Feat {
     }
 
     attackResult(event: AttackResultEvent) {
-        if (event.attack?.attack?.weapon()?.mod(this.character) == "str") {
+        if (event.hit && event.attack?.attack?.weapon()?.mod(this.character) == "str") {
             event.addDamage({
                 source: "Rage",
                 flatDmg: this.character.getAttribute(RageBonusDamageAttribute),
@@ -111,7 +111,7 @@ class Frenzy extends Feat {
     }
 
     attackResult(event: AttackResultEvent) {
-        if (!this.applied && this.character.hasEffect(RageEffect) && event.attack?.hasTag(RecklessTag)) {
+        if (event.hit && !this.applied && this.character.hasEffect(RageEffect) && event.attack?.hasTag(RecklessTag)) {
             const dice = Array(this.character.getAttribute(RageBonusDamageAttribute)).fill(6)
             event.addDamage({
                 source: "Frenzy",
@@ -135,7 +135,7 @@ class DivineFury extends Feat {
     }
 
     attackResult(event: AttackResultEvent) {
-        if (!this.applied && this.character.hasEffect(RageEffect) && event.attack?.attack.weapon()) {
+        if (event.hit && !this.applied && this.character.hasEffect(RageEffect) && event.attack?.attack.weapon()) {
             event.addDamage({
                 source: "DivineFury",
                 dice: [6],

--- a/dndsim/src/classes/Rogue.ts
+++ b/dndsim/src/classes/Rogue.ts
@@ -220,6 +220,7 @@ class BoomingBladeAction extends Feat {
         event.addDamage({
             source: "BoomingBlade",
             dice: Array(extraDice).fill(8),
+            type: 'thunder',
         })
     }
 }

--- a/dndsim/src/sim/Character.ts
+++ b/dndsim/src/sim/Character.ts
@@ -340,6 +340,6 @@ export class Character {
             spell,
         })
         this.events.emit("damage_roll", damageData)
-        target.addDamage(damage.source, Math.floor(damage.total() * multiplier))
+        target.addDamage(damage.source, damage.type, Math.floor(damage.total() * multiplier))
     }
 }

--- a/dndsim/src/sim/Target.ts
+++ b/dndsim/src/sim/Target.ts
@@ -1,5 +1,6 @@
 import { profBonus, rollDice } from "../util/helpers"
 import { log } from "../util/Log"
+import { DamageType } from "./types"
 
 const TARGET_AC = [
     13, // 1
@@ -71,8 +72,8 @@ export class Target {
         this.grappled = true
     }
 
-    addDamage(source: string, amount: number): void {
-        log.record(`Damage (${source})`, amount)
+    addDamage(source: string, type: DamageType, amount: number): void {
+        log.record(`Damage (${source}, ${type})`, amount)
         this.damage += amount
     }
 

--- a/dndsim/src/sim/coreFeats/Graze.ts
+++ b/dndsim/src/sim/coreFeats/Graze.ts
@@ -17,6 +17,7 @@ export class Graze extends Feat {
         ) {
             data.attack.target.addDamage(
                 "Graze",
+                weapon.damageType,
                 this.character?.mod(weapon.mod(this.character))
             )
         }

--- a/dndsim/src/sim/events/AttackResultEvent.ts
+++ b/dndsim/src/sim/events/AttackResultEvent.ts
@@ -1,4 +1,5 @@
 import { DamageRoll } from "../helpers/DamageRoll"
+import { DamageType } from "../types"
 import { AttackEvent } from "./AttackEvent"
 
 export class AttackResultEvent {
@@ -26,8 +27,16 @@ export class AttackResultEvent {
     addDamage(args: {
         source: string
         dice?: Array<number>
-        flatDmg?: number
+        flatDmg?: number,
+        type?: DamageType,
     }): void {
-        this.damageRolls.push(new DamageRoll(args))
+        const type = args.type ?? this.attack.attack.weapon()?.damageType
+
+        if (!type) {
+            throw new Error("Must specify damage if it can't fall back to the base weapon damage type")
+        }
+
+        const damageRoll = new DamageRoll({ ...args, type })
+        this.damageRolls.push(damageRoll)
     }
 }

--- a/dndsim/src/sim/helpers/DamageRoll.ts
+++ b/dndsim/src/sim/helpers/DamageRoll.ts
@@ -1,18 +1,23 @@
 import { diceRolls } from "../../util/helpers"
+import { DamageType } from "../types"
 
 export class DamageRoll {
     source: string
     dice: Array<number>
     flatDmg: number
+    type: DamageType
     rolls: Array<number>
+
     constructor(args: {
         source: string
         dice?: Array<number>
         flatDmg?: number
+        type: DamageType
     }) {
         this.source = args.source
         this.dice = args.dice ?? []
         this.flatDmg = args.flatDmg ?? 0
+        this.type = args.type
         this.rolls = diceRolls(this.dice)
     }
 

--- a/dndsim/src/sim/spells/Spell.ts
+++ b/dndsim/src/sim/spells/Spell.ts
@@ -1,6 +1,7 @@
 import { Character } from "../Character"
 import { DamageRoll } from "../helpers/DamageRoll"
 import { Target } from "../Target"
+import { DamageType } from "../types"
 import { SpellcastingSchool } from "./shared"
 
 export type SpellArgs = {
@@ -31,7 +32,7 @@ export class Spell {
         this.character = character
     }
 
-    end(character: Character): void {}
+    end(character: Character): void { }
 }
 
 export class TargetedSpell extends Spell {
@@ -43,7 +44,7 @@ export class TargetedSpell extends Spell {
         this.castTarget(character, target)
     }
 
-    castTarget(character: Character, target: Target): void {}
+    castTarget(character: Character, target: Target): void { }
 }
 
 export class ConcentrationSpell extends Spell {
@@ -65,6 +66,7 @@ export class ConcentrationSpell extends Spell {
 export class BasicSaveSpell extends Spell {
     dice: number[]
     flatDmg: number
+    type: DamageType
 
     constructor(
         args: {
@@ -72,11 +74,13 @@ export class BasicSaveSpell extends Spell {
             slot: number
             dice: number[]
             flatDmg?: number
+            type: DamageType
         } & Partial<SpellArgs>
     ) {
         super(args)
         this.dice = args.dice
-        this.flatDmg = args.flatDmg || 0
+        this.flatDmg = args.flatDmg ?? 0
+        this.type = args.type
     }
 
     cast(character: Character, target?: Target): void {
@@ -91,6 +95,7 @@ export class BasicSaveSpell extends Spell {
                 source: this.name,
                 dice: this.dice,
                 flatDmg: this.flatDmg,
+                type: this.type,
             }),
             spell: this,
             multiplier: saved ? 0.5 : 1,


### PR DESCRIPTION
I was using the damage roll event instead of the attack result event for the barbarian damage additions, which isn't what we wanted.