### PR TITLE
Refactor the Monk to use attributes

### DIFF
--- a/dndsim/src/classes/Barbarian.ts
+++ b/dndsim/src/classes/Barbarian.ts
@@ -51,7 +51,7 @@ class Rage extends Feat {
     }
 
     attackResult(event: AttackResultEvent) {
-        if (event.hit && event.attack?.attack?.weapon()?.mod(this.character) == "str") {
+        if (event.hit && event.attack?.attack?.weapon()?.stat(this.character, event.attack.attack) == "str") {
             event.addDamage({
                 source: "Rage",
                 flatDmg: this.character.getAttribute(RageBonusDamageAttribute),
@@ -84,7 +84,7 @@ class RecklessAttack extends Feat {
     }
 
     attackRoll(character: Character, event: AttackRollEvent) {
-        if (event.attack?.attack?.weapon()?.mod(character) == "str") {
+        if (event.attack?.attack?.weapon()?.stat(character, event.attack.attack) == "str") {
             event.adv = true
             event.attack.addTag(RecklessTag)
         }

--- a/dndsim/src/classes/Barbarian.ts
+++ b/dndsim/src/classes/Barbarian.ts
@@ -51,7 +51,7 @@ class Rage extends Feat {
     }
 
     attackResult(event: AttackResultEvent) {
-        if (event.hit && event.attack?.attack?.weapon()?.stat(this.character, event.attack.attack) == "str") {
+        if (event.hit && event.attack.attack.stat(this.character) == "str") {
             event.addDamage({
                 source: "Rage",
                 flatDmg: this.character.getAttribute(RageBonusDamageAttribute),
@@ -84,7 +84,7 @@ class RecklessAttack extends Feat {
     }
 
     attackRoll(character: Character, event: AttackRollEvent) {
-        if (event.attack?.attack?.weapon()?.stat(character, event.attack.attack) == "str") {
+        if (event.attack.attack.stat(character) == "str") {
             event.adv = true
             event.attack.addTag(RecklessTag)
         }

--- a/dndsim/src/classes/Barbarian.ts
+++ b/dndsim/src/classes/Barbarian.ts
@@ -99,7 +99,7 @@ class PrimalChampion extends Feat {
 }
 
 class Frenzy extends Feat {
-    applied = false
+    used = false
 
     apply(character: Character) {
         character.events.on("begin_turn", () => this.beginTurn())
@@ -107,23 +107,23 @@ class Frenzy extends Feat {
     }
 
     beginTurn() {
-        this.applied = false
+        this.used = false
     }
 
     attackResult(event: AttackResultEvent) {
-        if (event.hit && !this.applied && this.character.hasEffect(RageEffect) && event.attack?.hasTag(RecklessTag)) {
+        if (event.hit && !this.used && this.character.hasEffect(RageEffect) && event.attack?.hasTag(RecklessTag)) {
             const dice = Array(this.character.getAttribute(RageBonusDamageAttribute)).fill(6)
             event.addDamage({
                 source: "Frenzy",
                 dice,
             })
-            this.applied = true
+            this.used = true
         }
     }
 }
 
 class DivineFury extends Feat {
-    applied = false
+    used = false
 
     apply(character: Character) {
         character.events.on("begin_turn", () => this.beginTurn())
@@ -131,11 +131,11 @@ class DivineFury extends Feat {
     }
 
     beginTurn() {
-        this.applied = false
+        this.used = false
     }
 
     attackResult(event: AttackResultEvent) {
-        if (event.hit && !this.applied && this.character.hasEffect(RageEffect) && event.attack?.attack.weapon()) {
+        if (event.hit && !this.used && this.character.hasEffect(RageEffect) && event.attack?.attack.weapon()) {
             event.addDamage({
                 source: "DivineFury",
                 dice: [6],
@@ -144,7 +144,7 @@ class DivineFury extends Feat {
                 type: 'radiant',
 
             })
-            this.applied = true
+            this.used = true
         }
     }
 }

--- a/dndsim/src/classes/Fighter.ts
+++ b/dndsim/src/classes/Fighter.ts
@@ -214,7 +214,7 @@ class ToppleIfNecessaryAttackAction extends ActionOperation {
             character.weaponAttack({
                 target,
                 weapon,
-                tags: ["main_action"],
+                tags: ["main_action", "attack_action"],
             })
         }
     }

--- a/dndsim/src/classes/Monk.ts
+++ b/dndsim/src/classes/Monk.ts
@@ -22,7 +22,7 @@ import { BeforeAttackEvent } from "../sim/events/BeforeAttackEvent"
 const FlurryTag = "flurry"
 
 const MartialArtsDieAttribute = "martialArts"
-const flurryOfBlowsCountAttribute = "flurryOfBlowsCount"
+const FlurryOfBlowsCountAttribute = "flurryOfBlowsCount"
 
 function isUnarmedOrMonkWeapon(weapon: Weapon | undefined): boolean {
     if (!weapon) {
@@ -104,7 +104,7 @@ class FlurryOfBlowsOperation implements Operation {
     do(environment: Environment, character: Character): void {
         character.bonus.use()
         character.ki.use()
-        const numAttacks = character.getAttribute(flurryOfBlowsCountAttribute)
+        const numAttacks = character.getAttribute(FlurryOfBlowsCountAttribute)
         for (let i = 0; i < numAttacks; i++) {
             character.weaponAttack({
                 target: environment.target,
@@ -265,7 +265,7 @@ export class Monk {
         if (level >= 2) {
             feats.push(new Ki(level))
             feats.push(new UncannyMetabolism())
-            feats.push(new SetAttribute(flurryOfBlowsCountAttribute, 2))
+            feats.push(new SetAttribute(FlurryOfBlowsCountAttribute, 2))
             feats.push(new FlurryOfBlows(args.unarmedStrike))
         }
         // Level 3 (Deflect Attacks) is irrelevant/ignored
@@ -280,7 +280,7 @@ export class Monk {
         // Level 9 (Acrobatic Movement) is irrelevant
         // Level 10 (Self-Restoration) is irrelevant
         if (level >= 10) {
-            feats.push(new SetAttribute(flurryOfBlowsCountAttribute, 3))
+            feats.push(new SetAttribute(FlurryOfBlowsCountAttribute, 3))
         }
         if (level >= 11) {
             feats.push(new SetAttribute(MartialArtsDieAttribute, 10))

--- a/dndsim/src/classes/Monk.ts
+++ b/dndsim/src/classes/Monk.ts
@@ -8,25 +8,80 @@ import { ClassLevel } from "../sim/coreFeats/ClassLevel"
 import { AttackResultEvent } from "../sim/events/AttackResultEvent"
 import { BeginTurnEvent } from "../sim/events/BeginTurnEvent"
 import { Feat } from "../sim/Feat"
-import { applyFeatSchedule } from "../util/helpers"
+import { applyFeatSchedule, defaultMagicBonus } from "../util/helpers"
 import { WeaponMasteries } from "../feats/shared/WeaponMasteries"
-import { FinesseWeapon, UnarmedWeapon, Weapon } from "../sim/Weapon"
+import { LightWeapon, MartialWeapon, RangedWeapon, SimpleWeapon, UnarmedWeapon, Weapon } from "../sim/Weapon"
 import { WeaponMastery } from "../sim/types"
 import { Operation } from "../sim/actions/Operation"
 import { Environment } from "../sim/Environment"
 import { ExtraAttack } from "../feats/shared/ExtraAttack"
+import { SetAttribute } from "../feats/shared/SetAttribute"
+import { UnarmedStrike } from "../weapons/other/UnarmedStrike"
+import { BeforeAttackEvent } from "../sim/events/BeforeAttackEvent"
 
 const FlurryTag = "flurry"
 
-function martialArtsDie(level: number): number {
-    if (level >= 17) {
-        return 12
-    } else if (level >= 11) {
-        return 10
-    } else if (level >= 5) {
-        return 8
-    } else {
-        return 6
+const MartialArtsDieAttribute = "martialArts"
+const flurryOfBlowsCountAttribute = "flurryOfBlowsCount"
+
+function isUnarmedOrMonkWeapon(weapon: Weapon | undefined): boolean {
+    if (!weapon) {
+        return false
+    }
+
+    if (weapon.hasTag(UnarmedWeapon)) {
+        return true
+    }
+
+    if (weapon.hasTag(RangedWeapon)) {
+        return false
+    }
+
+    if (weapon.hasTag(SimpleWeapon)) {
+        return true
+    }
+
+    if (weapon.hasTag(MartialWeapon) && weapon.hasTag(LightWeapon)) {
+        return true
+    }
+
+    return false
+}
+
+class MartialArts extends Feat {
+    apply(character: Character) {
+        character.events.on("before_attack", (event) => this.beforeAttack(event))
+        character.events.on("attack_result", (event) => this.attackResult(event))
+    }
+
+    beforeAttack(event: BeforeAttackEvent) {
+        const weapon = event.attackEvent.attack.weapon()
+        if (weapon && !isUnarmedOrMonkWeapon(weapon)) {
+            return
+        }
+
+        event.attackEvent.attack.addStat("dex")
+    }
+
+    attackResult(event: AttackResultEvent) {
+        const weapon = event.attack?.attack.weapon()
+        if (!isUnarmedOrMonkWeapon(weapon)) {
+            return
+        }
+
+        const martialArtsDie = this.character.getAttribute(MartialArtsDieAttribute)
+
+        event.damageRolls
+            .filter((damageRoll) => damageRoll.hasTag("base_weapon_damage"))
+            .forEach((damageRoll) => {
+                if (damageRoll.dice.length == 0) {
+                    // It must be doing a base 1 damage. Replace it with the martial arts die
+                    damageRoll.addDice([martialArtsDie])
+                    damageRoll.flatDmg -= 1
+                } else {
+                    damageRoll.replaceDice(damageRoll.dice.map((die) => Math.max(die, martialArtsDie)))
+                }
+            })
     }
 }
 
@@ -40,13 +95,7 @@ class BodyAndMind extends Feat {
 class FlurryOfBlowsOperation implements Operation {
     repeatable: boolean = false
 
-    numAttacks: number
-    weapon: Weapon
-
-    constructor(numAttacks: number, weapon: Weapon) {
-        this.numAttacks = numAttacks
-        this.weapon = weapon
-    }
+    constructor(private unarmedStrike: UnarmedStrike) { }
 
     eligible(environment: Environment, character: Character): boolean {
         return character.ki.has() && character.bonus.has()
@@ -55,10 +104,11 @@ class FlurryOfBlowsOperation implements Operation {
     do(environment: Environment, character: Character): void {
         character.bonus.use()
         character.ki.use()
-        for (let i = 0; i < this.numAttacks; i++) {
+        const numAttacks = character.getAttribute(flurryOfBlowsCountAttribute)
+        for (let i = 0; i < numAttacks; i++) {
             character.weaponAttack({
                 target: environment.target,
-                weapon: this.weapon,
+                weapon: this.unarmedStrike,
                 tags: [FlurryTag],
             })
         }
@@ -68,10 +118,7 @@ class FlurryOfBlowsOperation implements Operation {
 class BonusActionAttackOperation implements Operation {
     repeatable: boolean = false
 
-    weapon: Weapon
-    constructor(weapon: Weapon) {
-        this.weapon = weapon
-    }
+    constructor(private weapon: Weapon) { }
 
     eligible(environment: Environment, character: Character): boolean {
         return character.bonus.has()
@@ -87,23 +134,14 @@ class BonusActionAttackOperation implements Operation {
 }
 
 class FlurryOfBlows extends Feat {
-    numAttacks: number
-    weapon: Weapon
-
-    constructor(numAttacks: number, weapon: Weapon) {
+    constructor(private unarmedStrike: UnarmedStrike) {
         super()
-        this.numAttacks = numAttacks
-        this.weapon = weapon
     }
 
     apply(character: Character): void {
         character.customTurn.addOperation(
             "after_action",
-            new FlurryOfBlowsOperation(this.numAttacks, this.weapon)
-        )
-        character.customTurn.addOperation(
-            "after_action",
-            new BonusActionAttackOperation(this.weapon)
+            new FlurryOfBlowsOperation(this.unarmedStrike)
         )
     }
 }
@@ -125,14 +163,10 @@ class OpenHandTechnique extends Feat {
 }
 
 class StunningStrike extends Feat {
-    weaponDie: number
     used: boolean = false
-    avoidOnGrapple: boolean
 
-    constructor(level: number, avoidOnGrapple: boolean = false) {
+    constructor(private avoidOnGrapple: boolean = false) {
         super()
-        this.weaponDie = martialArtsDie(level)
-        this.avoidOnGrapple = avoidOnGrapple
     }
 
     apply(character: Character): void {
@@ -168,11 +202,9 @@ class StunningStrike extends Feat {
 }
 
 class Ki extends Feat {
-    maxKi: number
 
-    constructor(maxKi: number) {
+    constructor(private maxKi: number) {
         super()
-        this.maxKi = maxKi
     }
 
     apply(character: Character): void {
@@ -213,23 +245,12 @@ class PerfectFocus extends Feat {
     }
 }
 
-class Fists extends Weapon {
-    constructor(args: { weaponDie: number; magicBonus?: number }) {
-        super({
-            name: "Fists",
-            numDice: 1,
-            die: args.weaponDie,
-            magicBonus: args.magicBonus,
-            tags: [FinesseWeapon, UnarmedWeapon],
-        })
-    }
-}
-
 export class Monk {
     static baseFeats(args: {
         level: number
         asis: Array<Feat>
-        masteries: WeaponMastery[]
+        masteries: WeaponMastery[],
+        unarmedStrike: UnarmedStrike,
     }): Feat[] {
         const { level, asis, masteries } = args
         const feats: Feat[] = []
@@ -237,26 +258,40 @@ export class Monk {
         if (level >= 1) {
             feats.push(new ClassLevel("Monk", level))
             feats.push(new WeaponMasteries(masteries))
+            feats.push(new SetAttribute(MartialArtsDieAttribute, 6))
+            feats.push(new MartialArts())
         }
         // Level 1 (Unarmored Defense) is irrelevant
         if (level >= 2) {
             feats.push(new Ki(level))
             feats.push(new UncannyMetabolism())
+            feats.push(new SetAttribute(flurryOfBlowsCountAttribute, 2))
+            feats.push(new FlurryOfBlows(args.unarmedStrike))
         }
         // Level 3 (Deflect Attacks) is irrelevant/ignored
         // Level 4 (Slow Fall) is irrelevant
         if (level >= 5) {
-            feats.push(new StunningStrike(level, true))
+            feats.push(new StunningStrike(true))
             feats.push(new ExtraAttack(2))
+            feats.push(new SetAttribute(MartialArtsDieAttribute, 8))
         }
         // Level 6 (Empowered Strikes) is irrelevant
         // Level 7 (Evasion) is irrelevant
         // Level 9 (Acrobatic Movement) is irrelevant
         // Level 10 (Self-Restoration) is irrelevant
+        if (level >= 10) {
+            feats.push(new SetAttribute(flurryOfBlowsCountAttribute, 3))
+        }
+        if (level >= 11) {
+            feats.push(new SetAttribute(MartialArtsDieAttribute, 10))
+        }
         // Level 13 (Deflect Energy) is irrelevant
         // Level 14 (Disciplined Survivor) is irrelevant
         if (level >= 15) {
             feats.push(new PerfectFocus())
+        }
+        if (level >= 17) {
+            feats.push(new SetAttribute(MartialArtsDieAttribute, 12))
         }
         // Level 18 (Superior Defense) is irrelevant
         if (level >= 20) {
@@ -284,20 +319,14 @@ export class Monk {
     }
 
     static createOpenHandMonk(level: number): Character {
+        const unarmedStrike = new UnarmedStrike({ magicBonus: defaultMagicBonus(level) })
+
         const character = new Character({
             stats: { str: 10, dex: 17, con: 10, int: 10, wis: 16, cha: 10 },
         })
 
-        const weaponDie = martialArtsDie(level)
-        const magicBonus = Math.floor(level / 4)
-        const fists = new Fists({ weaponDie, magicBonus })
-
         const feats: Feat[] = []
         feats.push(new TavernBrawler())
-
-        // Add flurry of blows
-        const numFlurryAttacks = level >= 10 ? 3 : 2
-        feats.push(new FlurryOfBlows(numFlurryAttacks, fists))
 
         feats.push(
             ...Monk.baseFeats({
@@ -310,6 +339,7 @@ export class Monk {
                     new AbilityScoreImprovement("wis"),
                     new IrresistibleOffense("dex"),
                 ],
+                unarmedStrike,
             })
         )
 
@@ -319,8 +349,12 @@ export class Monk {
 
         character.customTurn.addOperation(
             "action",
-            new DefaultAttackActionOperation(fists)
+            new DefaultAttackActionOperation(unarmedStrike)
         )
+
+        // This is out here instead of part of level 1 so that Flurry of Blows will always
+        // be prioritized over it
+        character.customTurn.addOperation("after_action", new BonusActionAttackOperation(unarmedStrike))
 
         return character
     }

--- a/dndsim/src/classes/Monk.ts
+++ b/dndsim/src/classes/Monk.ts
@@ -55,12 +55,9 @@ class MartialArts extends Feat {
     }
 
     beforeAttack(event: BeforeAttackEvent) {
-        const weapon = event.attackEvent.attack.weapon()
-        if (weapon && !isUnarmedOrMonkWeapon(weapon)) {
-            return
+        if (isUnarmedOrMonkWeapon(event.attackEvent.attack.weapon())) {
+            event.attackEvent.attack.addStat("dex")
         }
-
-        event.attackEvent.attack.addStat("dex")
     }
 
     attackResult(event: AttackResultEvent) {

--- a/dndsim/src/classes/Rogue.ts
+++ b/dndsim/src/classes/Rogue.ts
@@ -196,7 +196,7 @@ class BoomingBladeAction extends Feat {
         this.character.weaponAttack({
             target: data.target,
             weapon: this.weapon,
-            tags: ["main_action", "booming_blade"],
+            tags: ["main_action", "booming_blade", "magic_action"],
         })
     }
 
@@ -243,7 +243,7 @@ class RogueAction extends Feat {
         this.character.weaponAttack({
             target: data.target,
             weapon: this.weapon,
-            tags: ["main_action"],
+            tags: ["main_action", "attack_action"],
         })
 
         if (this.nickWeapon) {

--- a/dndsim/src/feats/general/Grappler.ts
+++ b/dndsim/src/feats/general/Grappler.ts
@@ -5,7 +5,7 @@ import { Feat } from "../../sim/Feat"
 import { UnarmedWeapon } from "../../sim/Weapon"
 
 export class Grappler extends Feat {
-    private applied = false
+    private used = false
 
     constructor(private stat: "str" | "dex") {
         super()
@@ -21,7 +21,7 @@ export class Grappler extends Feat {
     }
 
     beginTurn() {
-        this.applied = false
+        this.used = false
     }
 
     attackRoll(event: AttackRollEvent): void {
@@ -31,14 +31,14 @@ export class Grappler extends Feat {
     }
 
     attackResult(event: AttackResultEvent): void {
-        if (this.applied || !event.hit) {
+        if (this.used || !event.hit) {
             return
         }
         const attack = event.attack
         const weapon = attack.attack.weapon()
         if (attack.attack.hasTag('attack_action') && weapon?.hasTag(UnarmedWeapon)) {
             this.character.grapple(attack.target)
-            this.applied = true
+            this.used = true
         }
     }
 }

--- a/dndsim/src/feats/general/GreatWeaponMaster.ts
+++ b/dndsim/src/feats/general/GreatWeaponMaster.ts
@@ -1,14 +1,11 @@
 import { Character } from "../../sim/Character"
 import { Feat } from "../../sim/Feat"
-import { HeavyWeapon, Weapon } from "../../sim/Weapon"
+import { HeavyWeapon, RangedWeapon, UnarmedWeapon, Weapon } from "../../sim/Weapon"
 import { AttackResultEvent } from "../../sim/events/AttackResultEvent"
 
 export class GreatWeaponMaster extends Feat {
-    private weapon: Weapon
-
-    constructor(weapon: Weapon) {
+    constructor(private weapon: Weapon) {
         super()
-        this.weapon = weapon
     }
 
     apply(character: Character): void {
@@ -20,13 +17,19 @@ export class GreatWeaponMaster extends Feat {
         if (!data.hit) {
             return
         }
-        if (data.attack.attack.weapon()?.hasTag(HeavyWeapon)) {
+
+        const weapon = data.attack.attack.weapon()
+        if (!weapon) {
+            return
+        }
+
+        if (data.attack.attack.hasTag("attack_action") && weapon.hasTag(HeavyWeapon)) {
             data.addDamage({
                 source: "GreatWeaponMaster",
                 flatDmg: this.character.prof(),
             })
         }
-        if (data.crit && this.character.bonus.use("GreatWeaponMaster")) {
+        if (data.crit && !weapon.hasTag(RangedWeapon) && !weapon.hasTag(UnarmedWeapon) && this.character.bonus.use("GreatWeaponMaster")) {
             this.character.weaponAttack({
                 target: data.attack.target,
                 weapon: this.weapon,

--- a/dndsim/src/sim/Attack.ts
+++ b/dndsim/src/sim/Attack.ts
@@ -1,10 +1,12 @@
 import { Character } from "./Character"
 import { AttackResultEvent } from "./events/AttackResultEvent"
 import { Spell } from "./spells/Spell"
-import { RangedWeapon, Weapon } from "./Weapon"
+import { Stat } from "./types"
+import { FinesseWeapon, RangedWeapon, Weapon } from "./Weapon"
 
 export abstract class Attack {
     tags: Set<string> = new Set()
+    stats: Stat[] = []
 
     abstract name(): string
     abstract toHit(character: Character): number
@@ -28,6 +30,10 @@ export abstract class Attack {
     spell(): Spell | undefined {
         return undefined
     }
+
+    addStat(stat: Stat) {
+        this.stats.push(stat)
+    }
 }
 
 export class WeaponAttack extends Attack {
@@ -39,6 +45,13 @@ export class WeaponAttack extends Attack {
         if (args.tags) {
             args.tags.forEach((tag) => this.addTag(tag))
         }
+        if (this.weapon_.hasTag(FinesseWeapon)) {
+            this.stats = ["str", "dex"]
+        } else if (this.weapon_.hasTag(RangedWeapon)) {
+            this.stats = ["dex"]
+        } else {
+            this.stats = ["str"]
+        }
     }
 
     name(): string {
@@ -46,7 +59,7 @@ export class WeaponAttack extends Attack {
     }
 
     toHit(character: Character): number {
-        return this.weapon_.toHit(character)
+        return this.weapon_.toHit(character, this)
     }
 
     attackResult(args: AttackResultEvent, character: Character): void {
@@ -63,5 +76,9 @@ export class WeaponAttack extends Attack {
 
     weapon(): Weapon {
         return this.weapon_
+    }
+
+    addStat(stat: Stat) {
+        this.stats.push(stat)
     }
 }

--- a/dndsim/src/sim/Character.ts
+++ b/dndsim/src/sim/Character.ts
@@ -268,7 +268,7 @@ export class Character {
         const { target, attack } = args
         log.record(`Attack (${attack.name()})`, 1)
         const attackData = new AttackEvent({ target, attack })
-        this.events.emit("before_attack", new BeforeAttackEvent())
+        this.events.emit("before_attack", new BeforeAttackEvent(attackData))
         const toHit = attack.toHit(this)
         const rollResult = this.attackRoll(attackData, toHit)
 

--- a/dndsim/src/sim/Weapon.ts
+++ b/dndsim/src/sim/Weapon.ts
@@ -1,7 +1,4 @@
-import { Attack } from "./Attack"
-import { Character } from "./Character"
-import { AttackResultEvent } from "./events/AttackResultEvent"
-import { DamageType, Stat, WeaponMastery } from "./types"
+import { DamageType, WeaponMastery } from "./types"
 
 export const HeavyWeapon = "Heavy"
 export const TwoHandedWeapon = "TwoHanded"
@@ -55,46 +52,12 @@ export class Weapon {
         this.tags = new Set(args.tags)
     }
 
-    stat(character: Character, attack: Attack): Stat {
-        const statsWithValues = attack.stats.map((stat) => [stat, character.stat(stat)] as const);
-        return statsWithValues.reduce(([statA, valueA], [statB, valueB]) => {
-            if (valueA > valueB) {
-                return [statA, valueA]
-            } else {
-                return [statB, valueB]
-            }
-        })[0]
-    }
-
-    toHit(character: Character, attack: Attack): number {
-        return (
-            character.prof() +
-            character.mod(this.stat(character, attack)) +
-            this.attackBonus
-        )
-    }
-
     rolls(crit: boolean): Array<number> {
         let numDice = this.numDice
         if (crit) {
             numDice *= 2
         }
         return Array(numDice).fill(this.die)
-    }
-
-    attackResult(args: AttackResultEvent, character: Character): void {
-        if (args.hit) {
-            let damage = this.dmgBonus
-            if (!args.attack.hasTag("light")) {
-                damage += character.mod(this.stat(character, args.attack.attack))
-            }
-            args.addDamage({
-                source: this.name,
-                dice: Array(this.numDice).fill(this.die),
-                flatDmg: damage,
-                tags: new Set(["base_weapon_damage"]),
-            })
-        }
     }
 
     hasTag(tag: string): boolean {

--- a/dndsim/src/sim/actions/AttackAction.ts
+++ b/dndsim/src/sim/actions/AttackAction.ts
@@ -14,7 +14,7 @@ export function attackAction(args: {
     const { character, target, weapon } = args
     const numAttacks = args.character.getAttribute(NumAttacksAttribute)
     for (let i = 0; i < numAttacks; i++) {
-        character.weaponAttack({ target, weapon, tags: ["main_action"] })
+        character.weaponAttack({ target, weapon, tags: ["main_action", "attack_action"] })
     }
 }
 

--- a/dndsim/src/sim/actions/AttackAction.ts
+++ b/dndsim/src/sim/actions/AttackAction.ts
@@ -46,7 +46,7 @@ export class DefaultAttackActionOperation extends AttackActionOperation {
             character.weaponAttack({
                 target: environment.target,
                 weapon,
-                tags: ["main_action"],
+                tags: ["attack_action", "main_action"],
             })
         })
     }

--- a/dndsim/src/sim/coreFeats/Graze.ts
+++ b/dndsim/src/sim/coreFeats/Graze.ts
@@ -18,7 +18,7 @@ export class Graze extends Feat {
             data.attack.target.addDamage(
                 "Graze",
                 weapon.damageType,
-                this.character?.mod(weapon.mod(this.character))
+                this.character?.mod(weapon.stat(this.character, data.attack.attack))
             )
         }
     }

--- a/dndsim/src/sim/coreFeats/Graze.ts
+++ b/dndsim/src/sim/coreFeats/Graze.ts
@@ -18,7 +18,7 @@ export class Graze extends Feat {
             data.attack.target.addDamage(
                 "Graze",
                 weapon.damageType,
-                this.character?.mod(weapon.stat(this.character, data.attack.attack))
+                this.character?.mod(data.attack.attack.stat(this.character))
             )
         }
     }

--- a/dndsim/src/sim/coreFeats/Topple.ts
+++ b/dndsim/src/sim/coreFeats/Topple.ts
@@ -15,7 +15,7 @@ export class Topple extends Feat {
             weapon.mastery === "Topple" &&
             data.hit &&
             this.character.masteries.has("Topple") &&
-            !target.save(this.character.dc(weapon.mod(this.character)))
+            !target.save(this.character.dc(weapon.stat(this.character, data.attack.attack)))
         ) {
             target.knockProne()
         }

--- a/dndsim/src/sim/coreFeats/Topple.ts
+++ b/dndsim/src/sim/coreFeats/Topple.ts
@@ -15,7 +15,7 @@ export class Topple extends Feat {
             weapon.mastery === "Topple" &&
             data.hit &&
             this.character.masteries.has("Topple") &&
-            !target.save(this.character.dc(weapon.stat(this.character, data.attack.attack)))
+            !target.save(this.character.dc(data.attack.attack.stat(this.character)))
         ) {
             target.knockProne()
         }

--- a/dndsim/src/sim/events/AttackResultEvent.ts
+++ b/dndsim/src/sim/events/AttackResultEvent.ts
@@ -29,6 +29,7 @@ export class AttackResultEvent {
         dice?: Array<number>
         flatDmg?: number,
         type?: DamageType,
+        tags?: Set<string>,
     }): void {
         const type = args.type ?? this.attack.attack.weapon()?.damageType
 

--- a/dndsim/src/sim/events/BeforeAttackEvent.ts
+++ b/dndsim/src/sim/events/BeforeAttackEvent.ts
@@ -1,5 +1,10 @@
+import { AttackEvent } from "./AttackEvent"
 import { CharacterEvent } from "./CharacterEvent"
 
 export class BeforeAttackEvent extends CharacterEvent {
     name: "before_attack" = "before_attack"
+
+    constructor(public attackEvent: AttackEvent) {
+        super()
+    }
 }

--- a/dndsim/src/sim/helpers/DamageRoll.ts
+++ b/dndsim/src/sim/helpers/DamageRoll.ts
@@ -7,22 +7,30 @@ export class DamageRoll {
     flatDmg: number
     type: DamageType
     rolls: Array<number>
+    tags: Set<string>
 
     constructor(args: {
         source: string
         dice?: Array<number>
         flatDmg?: number
-        type: DamageType
+        type: DamageType,
+        tags?: Set<string>,
     }) {
         this.source = args.source
         this.dice = args.dice ?? []
         this.flatDmg = args.flatDmg ?? 0
         this.type = args.type
         this.rolls = diceRolls(this.dice)
+        this.tags = args.tags ?? new Set()
     }
 
     total(): number {
         return this.flatDmg + this.rolls.reduce((a, b) => a + b, 0)
+    }
+
+    replaceDice(dice: Array<number>): void {
+        this.dice = dice
+        this.reroll()
     }
 
     reroll(): void {
@@ -33,5 +41,9 @@ export class DamageRoll {
         this.dice.push(...dice)
         const rolls = diceRolls(dice)
         this.rolls.push(...rolls)
+    }
+
+    hasTag(tag: string): boolean {
+        return this.tags.has(tag)
     }
 }

--- a/dndsim/src/util/EventLoop.ts
+++ b/dndsim/src/util/EventLoop.ts
@@ -4,8 +4,8 @@ type ListenerMap<
     Event extends string,
     EventMapping extends Record<Event, any>
 > = {
-    [eventName in Event]?: Set<Listener<EventMapping[eventName]>>
-}
+        [eventName in Event]?: Set<Listener<EventMapping[eventName]>>
+    }
 
 export class EventLoop<
     Event extends string,

--- a/dndsim/src/weapons/other/UnarmedStrike.ts
+++ b/dndsim/src/weapons/other/UnarmedStrike.ts
@@ -1,0 +1,20 @@
+import {
+    UnarmedWeapon,
+    Weapon,
+    WeaponArgs,
+} from "../../sim/Weapon"
+
+export class UnarmedStrike extends Weapon {
+    constructor(args?: Partial<WeaponArgs>) {
+        super({
+            name: "UnarmedStrike",
+            numDice: 0,
+            die: 1,
+            dmgBonus: 1,
+            damageType: "bludgeoning",
+            tags: [UnarmedWeapon],
+            ...args,
+        })
+    }
+}
+


### PR DESCRIPTION
As part of this, I also fixed the Great Weapon Master and Grappler feats to only apply to attacks made with the Attack action and restricted Grappler to only once per turn. The tests now fail because of those changes. Is there a good automated way to fix the tests?

I changed the way using Dex for monk weapons and unarmed strikes is handled, so that it no longer needs to be determined on the weapon itself, and in the future can be used for things that let you use other modifiers.

I fixed the magic bonus for the Monk to match the others.