### PR TITLE
Implement critical misses and critical hits always missing/hitting

### DIFF
--- a/dndsim/src/feats/epic/CombatProwess.ts
+++ b/dndsim/src/feats/epic/CombatProwess.ts
@@ -25,11 +25,9 @@ export class CombatProwess extends Feat {
     }
 
     attackRoll(event: AttackRollEvent): void {
-        if (event.roll() < event.attack.target.ac) {
-            if (!this.used) {
-                this.used = true
-                event.situationalBonus += 20 // Effectively hit
-            }
+        if (!this.used && !event.hits()) {
+            this.used = true
+            event.autoHit = true
         }
     }
 }

--- a/dndsim/src/feats/epic/Fate.ts
+++ b/dndsim/src/feats/epic/Fate.ts
@@ -8,6 +8,7 @@ import { rollDice } from "../../util/helpers"
 // might be useful for causing the target to fail a save.
 export class Fate extends Feat {
     used: boolean = false
+
     constructor(private stat: Stat) {
         super()
     }
@@ -15,16 +16,16 @@ export class Fate extends Feat {
     apply(character: Character): void {
         character.increaseStatMax(this.stat, 1)
         character.increaseStat(this.stat, 1)
-        character.events.on("short_rest", () => this.beginTurn())
+        character.events.on("short_rest", () => this.shortRest())
         character.events.on("attack_roll", (event) => this.attackRoll(event))
     }
 
-    beginTurn(): void {
+    shortRest(): void {
         this.used = false
     }
 
     attackRoll(event: AttackRollEvent): void {
-        if (!this.used && !event.hits() && !event.criticalMiss()) {
+        if (!this.used && !event.hits() && !event.isCritMiss()) {
             this.used = true
             event.situationalBonus += rollDice(2, 4)
         }

--- a/dndsim/src/feats/epic/Fate.ts
+++ b/dndsim/src/feats/epic/Fate.ts
@@ -1,6 +1,5 @@
 import { Character } from "../../sim/Character"
 import { AttackRollEvent } from "../../sim/events/AttackRollEvent"
-import { BeginTurnEvent } from "../../sim/events/BeginTurnEvent"
 import { Feat } from "../../sim/Feat"
 import { Stat } from "../../sim/types"
 import { rollDice } from "../../util/helpers"
@@ -8,26 +7,24 @@ import { rollDice } from "../../util/helpers"
 // We only use Fate on attack rolls. In the future, it
 // might be useful for causing the target to fail a save.
 export class Fate extends Feat {
-    stat: Stat
     used: boolean = false
-    constructor(stat: Stat) {
+    constructor(private stat: Stat) {
         super()
-        this.stat = stat
     }
 
     apply(character: Character): void {
         character.increaseStatMax(this.stat, 1)
         character.increaseStat(this.stat, 1)
-        character.events.on("begin_turn", (event) => this.beginTurn(event))
+        character.events.on("short_rest", () => this.beginTurn())
         character.events.on("attack_roll", (event) => this.attackRoll(event))
     }
 
-    beginTurn(event: BeginTurnEvent): void {
+    beginTurn(): void {
         this.used = false
     }
 
     attackRoll(event: AttackRollEvent): void {
-        if (event.roll() < event.attack.target.ac) {
+        if (!this.used && !event.hits() && !event.criticalMiss()) {
             this.used = true
             event.situationalBonus += rollDice(2, 4)
         }

--- a/dndsim/src/feats/shared/ImprovedCritical.ts
+++ b/dndsim/src/feats/shared/ImprovedCritical.ts
@@ -3,16 +3,13 @@ import { AttackRollEvent } from "../../sim/events/AttackRollEvent"
 import { Feat } from "../../sim/Feat"
 
 export class ImprovedCritical extends Feat {
-    minCrit: number
-
-    constructor(minCrit: number) {
+    constructor(private minCrit: number) {
         super()
-        this.minCrit = minCrit
     }
 
     apply(character: Character): void {
         character.events.on("attack_roll", (data: AttackRollEvent) => {
-            if (!data.minCrit || data.minCrit >= this.minCrit) {
+            if (data.minCrit >= this.minCrit) {
                 data.minCrit = this.minCrit
             }
         })

--- a/dndsim/src/sim/Character.ts
+++ b/dndsim/src/sim/Character.ts
@@ -277,20 +277,20 @@ export class Character {
         } else {
             log.record(`Miss (${attack.name()})`, 1)
         }
-        if (rollResult.criticalHit()) {
+        if (rollResult.isCrit()) {
             log.record(`Crit (${attack.name()})`, 1)
         }
 
         const attackResult = new AttackResultEvent({
             attack: attackData,
             hit: rollResult.hits(),
-            crit: rollResult.criticalHit(),
+            crit: rollResult.isCrit(),
             roll: rollResult.roll(),
         })
         args.attack.attackResult(attackResult, this)
         this.events.emit("attack_result", attackResult)
         for (const damage of attackResult.damageRolls) {
-            if (rollResult.criticalHit()) {
+            if (rollResult.isCrit()) {
                 damage.dice = damage.dice.concat(damage.dice)
             }
             this.doDamage({

--- a/dndsim/src/sim/Character.ts
+++ b/dndsim/src/sim/Character.ts
@@ -271,33 +271,26 @@ export class Character {
         this.events.emit("before_attack", new BeforeAttackEvent())
         const toHit = attack.toHit(this)
         const rollResult = this.attackRoll(attackData, toHit)
-        const roll = rollResult.roll()
-        const minCrit = rollResult.minCrit
-            ? rollResult.minCrit
-            : attack.minCrit()
-        const crit = roll >= minCrit
-        const rollTotal = roll + toHit + rollResult.situationalBonus
-        const hit = rollTotal >= target.ac
 
-        if (hit) {
+        if (rollResult.hits()) {
             log.record(`Hit (${attack.name()})`, 1)
         } else {
             log.record(`Miss (${attack.name()})`, 1)
         }
-        if (crit) {
+        if (rollResult.criticalHit()) {
             log.record(`Crit (${attack.name()})`, 1)
         }
 
         const attackResult = new AttackResultEvent({
             attack: attackData,
-            hit,
-            crit,
-            roll,
+            hit: rollResult.hits(),
+            crit: rollResult.criticalHit(),
+            roll: rollResult.roll(),
         })
         args.attack.attackResult(attackResult, this)
         this.events.emit("attack_result", attackResult)
         for (const damage of attackResult.damageRolls) {
-            if (crit) {
+            if (rollResult.criticalHit()) {
                 damage.dice = damage.dice.concat(damage.dice)
             }
             this.doDamage({

--- a/dndsim/src/sim/events/AttackRollEvent.ts
+++ b/dndsim/src/sim/events/AttackRollEvent.ts
@@ -39,20 +39,20 @@ export class AttackRollEvent {
         return this.roll1
     }
 
-    criticalHit(): boolean {
+    isCrit(): boolean {
         return this.roll() >= this.minCrit
     }
 
-    criticalMiss(): boolean {
+    isCritMiss(): boolean {
         return this.roll() === 1
     }
 
     hits(): boolean {
-        if (this.autoHit || this.criticalHit()) {
+        if (this.autoHit || this.isCrit()) {
             return true
         }
 
-        if (this.criticalMiss()) {
+        if (this.isCritMiss()) {
             return false
         }
 

--- a/dndsim/src/sim/events/AttackRollEvent.ts
+++ b/dndsim/src/sim/events/AttackRollEvent.ts
@@ -10,11 +10,13 @@ export class AttackRollEvent {
     roll1: number = 0
     roll2: number = 0
     situationalBonus: number = 0
-    minCrit?: number
+    minCrit: number
+    autoHit: boolean = false
 
     constructor(args: { attack: AttackEvent; toHit: number }) {
         this.attack = args.attack
         this.toHit = args.toHit
+        this.minCrit = args.attack.attack.minCrit()
         this.roll1 = rollDice(1, 20)
         this.roll2 = rollDice(1, 20)
     }
@@ -37,7 +39,23 @@ export class AttackRollEvent {
         return this.roll1
     }
 
+    criticalHit(): boolean {
+        return this.roll() >= this.minCrit
+    }
+
+    criticalMiss(): boolean {
+        return this.roll() === 1
+    }
+
     hits(): boolean {
+        if (this.autoHit || this.criticalHit()) {
+            return true
+        }
+
+        if (this.criticalMiss()) {
+            return false
+        }
+
         return (
             this.roll() + this.toHit + this.situationalBonus >=
             this.attack.target.ac


### PR DESCRIPTION
The Fate and Combat Prowess epic boons weren't factoring in to-hit bonuses and such for calculating whether they should be used.

The critical miss could potentially make the boon of Fate incapable of getting a hit.