### PR TITLE
Add the Soul Knife rogue

### DIFF
--- a/dndsim/src/feats/general/GreatWeaponMaster.ts
+++ b/dndsim/src/feats/general/GreatWeaponMaster.ts
@@ -29,7 +29,7 @@ export class GreatWeaponMaster extends Feat {
                 flatDmg: this.character.prof(),
             })
         }
-        if (data.crit && !weapon.hasTag(RangedWeapon) && !weapon.hasTag(UnarmedWeapon) && this.character.bonus.use("GreatWeaponMaster")) {
+        if (data.crit && !weapon.hasTag(RangedWeapon) && !weapon.hasTag(UnarmedWeapon) && this.character.bonus.use(1, "GreatWeaponMaster")) {
             this.character.weaponAttack({
                 target: data.attack.target,
                 weapon: this.weapon,

--- a/dndsim/src/sim/Character.ts
+++ b/dndsim/src/sim/Character.ts
@@ -189,8 +189,8 @@ export class Character {
         return this.resources.get(name)!
     }
 
-    hasResource(name: string): boolean {
-        return this.resources.get(name)?.has() ?? false;
+    hasResource(name: string, amount: number = 1): boolean {
+        return this.resources.get(name)?.has(amount) ?? false;
     }
 
     useResource(name: string, amount: number = 1) {

--- a/dndsim/src/sim/Character.ts
+++ b/dndsim/src/sim/Character.ts
@@ -193,8 +193,8 @@ export class Character {
         return this.resources.get(name)?.has() ?? false;
     }
 
-    useResource(name: string) {
-        this.getResource(name).use()
+    useResource(name: string, amount: number = 1) {
+        this.getResource(name).use(amount)
     }
 
     // =============================

--- a/dndsim/src/sim/Weapon.ts
+++ b/dndsim/src/sim/Weapon.ts
@@ -16,7 +16,7 @@ export const MartialWeapon = "Martial"
 
 export type WeaponArgs = {
     name: string
-    numDice: number
+    numDice?: number
     die: number
     damageType?: DamageType
     minCrit?: number
@@ -41,7 +41,7 @@ export class Weapon {
 
     constructor(args: WeaponArgs) {
         this.name = args.name
-        this.numDice = args.numDice
+        this.numDice = args.numDice ?? 1
         this.die = args.die
         this.damageType = args.damageType ?? "unknown"
         this.minCrit = args.minCrit ?? 20

--- a/dndsim/src/sim/resources/Resource.ts
+++ b/dndsim/src/sim/resources/Resource.ts
@@ -44,13 +44,22 @@ export class Resource {
         this.count = newCount
     }
 
-    use(reason?: string): boolean {
-        if (this.count > 0) {
+    use(amount: number): boolean
+    use(reason?: string, amount?: number): boolean
+    use(reasonOrAmount?: number | string, amountIfReason?: number): boolean {
+        const reason = typeof reasonOrAmount === "string" ? reasonOrAmount : undefined
+        const amount = typeof amountIfReason === "number"
+            ? amountIfReason
+            : typeof reasonOrAmount === "number"
+                ? reasonOrAmount
+                : 1
+
+        if (this.count >= amount) {
             log.record(
                 `Resource used: ${this.name}${reason ? ` (${reason})` : ""}`,
-                1
+                amount
             )
-            this.count -= 1
+            this.count -= amount
             return true
         }
         return false

--- a/dndsim/src/sim/resources/Resource.ts
+++ b/dndsim/src/sim/resources/Resource.ts
@@ -44,16 +44,7 @@ export class Resource {
         this.count = newCount
     }
 
-    use(amount: number): boolean
-    use(reason?: string, amount?: number): boolean
-    use(reasonOrAmount?: number | string, amountIfReason?: number): boolean {
-        const reason = typeof reasonOrAmount === "string" ? reasonOrAmount : undefined
-        const amount = typeof amountIfReason === "number"
-            ? amountIfReason
-            : typeof reasonOrAmount === "number"
-                ? reasonOrAmount
-                : 1
-
+    use(amount: number = 1, reason?: string): boolean {
         if (this.count >= amount) {
             log.record(
                 `Resource used: ${this.name}${reason ? ` (${reason})` : ""}`,
@@ -65,8 +56,7 @@ export class Resource {
         return false
     }
 
-    has(amount?: number): boolean {
-        amount = amount ?? 1
+    has(amount: number = 1): boolean {
         return this.count >= amount
     }
 


### PR DESCRIPTION
I'm not sure how best to tell it not to use Steady Aim for the Soul Knife, since it has the better bonus action of using its psychic blade. At least, I'm assuming that it's better, since it gets to add the dexterity modifier. I'm not sure if it should also be allowed to use Nick while using the special bonus action.